### PR TITLE
Feature/exam integration - Integration Exam,Session, Assessment into ERT

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # TDS_ExamResultsTransmitter
+
+## Summary
+
+The ExamResultsTransmitter service is responsible for collecting the exam, segment, and assessment data necessary to 
+construct the TRT (Test Results Transmission) XML document.
+ 
+## Resources
+- [TRT Specification](http://www.smarterapp.org/documents/TestResultsTransmissionFormat.pdf)
+- [TRT XSD](http://www.smarterapp.org/documents/TestResultsTransmissionFormat_Schema.xsd)
+- [TRT Format Sample](http://www.smarterapp.org/documents/TestResultsTransmissionFormat_Sample.xml)

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 		<tds-common.version>0.0.6</tds-common.version>
 		<tds-exam-client.version>0.0.9</tds-exam-client.version>
 		<tds-session-client.version>0.0.4</tds-session-client.version>
-		<tds-assessment-client.version>0.0.6</tds-assessment-client.version>
+		<tds-assessment-client.version>0.0.7</tds-assessment-client.version>
 	</properties>
 
 	<dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -25,9 +25,12 @@
 		<unit-tests.skip>false</unit-tests.skip>
 		<integration-tests.skip>true</integration-tests.skip>
 		<maven.release.plugin.version>2.5.3</maven.release.plugin.version>
+		<jaxb-maven.version>2.3.1</jaxb-maven.version>
 		<!-- TDS Version Props -->
 		<tds-common.version>0.0.6</tds-common.version>
-		<tds-exam-client.version>0.0.8</tds-exam-client.version>
+		<tds-exam-client.version>0.0.9-SNAPSHOT</tds-exam-client.version>
+		<tds-session-client.version>0.0.4</tds-session-client.version>
+		<tds-assessment-client.version>0.0.6</tds-assessment-client.version>
 	</properties>
 
 	<dependencyManagement>
@@ -48,6 +51,16 @@
 			<groupId>org.opentestsystem.delivery</groupId>
 			<artifactId>tds-exam-client</artifactId>
 			<version>${tds-exam-client.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.opentestsystem.delivery</groupId>
+			<artifactId>tds-session-client</artifactId>
+			<version>${tds-session-client.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.opentestsystem.delivery</groupId>
+			<artifactId>tds-assessment-client</artifactId>
+			<version>${tds-assessment-client.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.opentestsystem.delivery</groupId>
@@ -178,6 +191,23 @@
 							<include>${project.build.finalName}.jar</include>
 						</resource>
 					</resources>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>jaxb2-maven-plugin</artifactId>
+				<version>${jaxb-maven.version}</version>
+				<executions>
+					<execution>
+						<id>xjc</id>
+						<goals>
+							<goal>xjc</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<!-- The package of your generated sources -->
+					<packageName>tds.exam.results.trt</packageName>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 		<jaxb-maven.version>2.3.1</jaxb-maven.version>
 		<!-- TDS Version Props -->
 		<tds-common.version>0.0.6</tds-common.version>
-		<tds-exam-client.version>0.0.9-SNAPSHOT</tds-exam-client.version>
+		<tds-exam-client.version>0.0.9</tds-exam-client.version>
 		<tds-session-client.version>0.0.4</tds-session-client.version>
 		<tds-assessment-client.version>0.0.6</tds-assessment-client.version>
 	</properties>

--- a/src/main/java/tds/exam/results/TdsExamReportApplication.java
+++ b/src/main/java/tds/exam/results/TdsExamReportApplication.java
@@ -5,7 +5,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
 public class TdsExamReportApplication {
-
 	public static void main(String[] args) {
 		SpringApplication.run(TdsExamReportApplication.class, args);
 	}

--- a/src/main/java/tds/exam/results/configuration/ExamResultsTransmitterServiceProperties.java
+++ b/src/main/java/tds/exam/results/configuration/ExamResultsTransmitterServiceProperties.java
@@ -1,0 +1,62 @@
+package tds.exam.results.configuration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "exam-results-transmitter-service")
+public class ExamResultsTransmitterServiceProperties {
+    private String sessionUrl = "";
+    private String examUrl = "";
+    private String assessmentUrl = "";
+
+    /**
+     * Get the URL for the session microservice.
+     *
+     * @return session microservice URL
+     */
+    public String getSessionUrl() {
+        return sessionUrl;
+    }
+
+    public void setSessionUrl(final String sessionUrl) {
+        if (sessionUrl == null) throw new IllegalArgumentException("sessionUrl cannot be null");
+        this.sessionUrl = removeTrailingSlash(sessionUrl);
+    }
+
+    /**
+     * Get the URL for the exam microservice.
+     *
+     * @return exam microservice URL
+     */
+    public String getExamUrl() {
+        return examUrl;
+    }
+
+    public void setExamUrl(final String examUrl) {
+        if (examUrl == null) throw new IllegalArgumentException("examUrl cannot be null");
+        this.examUrl = removeTrailingSlash(examUrl);
+    }
+
+    /**
+     * Get the URL for the assessment microservice.
+     *
+     * @return assessment microservice URL
+     */
+    public String getAssessmentUrl() {
+        return assessmentUrl;
+    }
+
+    public void setAssessmentUrl(final String assessmentUrl) {
+        if (assessmentUrl == null) throw new IllegalArgumentException("asssessmentUrl cannot be null");
+        this.assessmentUrl = removeTrailingSlash(assessmentUrl);
+    }
+
+    private String removeTrailingSlash(String url) {
+        if (url.endsWith("/")) {
+            return url.substring(0, url.length() - 1);
+        } else {
+            return url;
+        }
+    }
+}

--- a/src/main/java/tds/exam/results/configuration/SupportApplicationConfiguration.java
+++ b/src/main/java/tds/exam/results/configuration/SupportApplicationConfiguration.java
@@ -1,0 +1,10 @@
+package tds.exam.results.configuration;
+
+public class SupportApplicationConfiguration {
+    private SupportApplicationConfiguration() {
+    }
+
+    public static final String SESSION_APP_CONTEXT = "sessions";
+    public static final String ASSESSMENT_APP_CONTEXT = "assessments";
+    public static final String EXAM_APP_CONTEXT = "exam";
+}

--- a/src/main/java/tds/exam/results/configuration/web/ExamResultsTransmitterApplicationConfiguration.java
+++ b/src/main/java/tds/exam/results/configuration/web/ExamResultsTransmitterApplicationConfiguration.java
@@ -1,11 +1,17 @@
 package tds.exam.results.configuration.web;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
 
 import tds.common.configuration.CacheConfiguration;
 import tds.common.configuration.RestTemplateConfiguration;
 import tds.common.configuration.SecurityConfiguration;
+import tds.exam.results.trt.TDSReport;
 
 /**
  * Configuration for the exam results transmitter microservice
@@ -17,4 +23,11 @@ import tds.common.configuration.SecurityConfiguration;
     SecurityConfiguration.class
 })
 public class ExamResultsTransmitterApplicationConfiguration {
+    @Bean
+    public JAXBContext jaxbContext() throws JAXBException {
+        JAXBContext contextObj = JAXBContext.newInstance(TDSReport.class);
+        Marshaller marshallerObj = contextObj.createMarshaller();
+        marshallerObj.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
+        return contextObj;
+    }
 }

--- a/src/main/java/tds/exam/results/configuration/web/ExamResultsTransmitterApplicationConfiguration.java
+++ b/src/main/java/tds/exam/results/configuration/web/ExamResultsTransmitterApplicationConfiguration.java
@@ -3,6 +3,7 @@ package tds.exam.results.configuration.web;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
+import tds.common.configuration.CacheConfiguration;
 import tds.common.configuration.RestTemplateConfiguration;
 import tds.common.configuration.SecurityConfiguration;
 
@@ -11,6 +12,7 @@ import tds.common.configuration.SecurityConfiguration;
  */
 @Configuration
 @Import({
+    CacheConfiguration.class,
     RestTemplateConfiguration.class,
     SecurityConfiguration.class
 })

--- a/src/main/java/tds/exam/results/mappers/CommentMapper.java
+++ b/src/main/java/tds/exam/results/mappers/CommentMapper.java
@@ -1,0 +1,23 @@
+package tds.exam.results.mappers;
+
+import java.util.List;
+
+import tds.exam.ExpandableExam;
+import tds.exam.results.mappers.utils.JaxbMapperUtils;
+import tds.exam.results.trt.TDSReport;
+
+/**
+ * A mapper class for mapping examinee notes to the JAXB {@link tds.exam.results.trt.TDSReport.Comment} object
+ */
+public class CommentMapper {
+    public static void mapComments(final List<TDSReport.Comment> comments, final ExpandableExam expandableExam) {
+        expandableExam.getExamineeNotes().forEach(note -> {
+            TDSReport.Comment comment = new TDSReport.Comment();
+            comment.setContext(note.getContext().toString());
+            comment.setItemPosition(String.valueOf(note.getItemPosition()));
+            comment.setDate(JaxbMapperUtils.convertInstantToGregorianCalendar(note.getCreatedAt()));
+            comment.setContent(note.getNote());
+            comments.add(comment);
+        });
+    }
+}

--- a/src/main/java/tds/exam/results/mappers/ExamineeMapper.java
+++ b/src/main/java/tds/exam/results/mappers/ExamineeMapper.java
@@ -1,0 +1,39 @@
+package tds.exam.results.mappers;
+
+import java.util.List;
+
+import tds.exam.ExpandableExam;
+import tds.exam.results.mappers.utils.JaxbMapperUtils;
+import tds.exam.results.trt.Context;
+import tds.exam.results.trt.TDSReport;
+
+/**
+ * A mapper class for mapping examinee data to the JAXB {@link tds.exam.results.trt.TDSReport.Examinee} object
+ */
+public class ExamineeMapper {
+    public static TDSReport.Examinee mapExaminee(final ExpandableExam expandableExam) {
+        TDSReport.Examinee examinee = new TDSReport.Examinee();
+        examinee.setKey(expandableExam.getExam().getStudentId());
+        List<Object> attributesAndRelationships = examinee.getExamineeAttributeOrExamineeRelationship();
+
+        expandableExam.getExamineeRelationships().forEach(relationship -> {
+            TDSReport.Examinee.ExamineeRelationship reportRelationship = new TDSReport.Examinee.ExamineeRelationship();
+            reportRelationship.setName(relationship.getName());
+            reportRelationship.setValue(relationship.getValue());
+            reportRelationship.setContext(Context.fromValue(relationship.getContext().name()));
+            reportRelationship.setContextDate(JaxbMapperUtils.convertInstantToGregorianCalendar(relationship.getCreatedAt()));
+            attributesAndRelationships.add(reportRelationship);
+        });
+
+        expandableExam.getExamineeAttributes().forEach(attribute -> {
+            TDSReport.Examinee.ExamineeAttribute reportAttribute = new TDSReport.Examinee.ExamineeAttribute();
+            reportAttribute.setName(attribute.getName());
+            reportAttribute.setValue(attribute.getValue());
+            reportAttribute.setContext(Context.fromValue(attribute.getContext().name()));
+            reportAttribute.setContextDate(JaxbMapperUtils.convertInstantToGregorianCalendar(attribute.getCreatedAt()));
+            attributesAndRelationships.add(reportAttribute);
+        });
+
+        return examinee;
+    }
+}

--- a/src/main/java/tds/exam/results/mappers/OpportunityMapper.java
+++ b/src/main/java/tds/exam/results/mappers/OpportunityMapper.java
@@ -1,0 +1,184 @@
+package tds.exam.results.mappers;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import tds.assessment.Assessment;
+import tds.assessment.Item;
+import tds.exam.Exam;
+import tds.exam.ExamAccommodation;
+import tds.exam.ExamItem;
+import tds.exam.ExamItemResponse;
+import tds.exam.ExamItemResponseScore;
+import tds.exam.ExamPage;
+import tds.exam.ExamSegment;
+import tds.exam.ExamStatusCode;
+import tds.exam.ExpandableExam;
+import tds.exam.results.trt.ScoreInfoType;
+import tds.exam.results.trt.TDSReport;
+import tds.session.Session;
+
+import tds.exam.results.mappers.utils.JaxbMapperUtils;
+
+/**
+ * A class used for mapping a {@link tds.exam.results.trt.TDSReport.Opportunity} object from Exam and Session data
+ */
+@Component
+public class OpportunityMapper {
+    private static final String ADMINISTRATION_CONDITION_INVALIDATED = "IN";
+    private static final float ITEM_NOT_SCORED_VALUE = -1;
+    private static final String DEFAULT_ALGORITHM_VERSION = "0";
+
+    public static TDSReport.Opportunity mapOpportunity(final ExpandableExam expandableExam, final Session session,
+                                                       final Assessment assessment) {
+        final Exam exam = expandableExam.getExam();
+        TDSReport.Opportunity opportunity = new TDSReport.Opportunity();
+        opportunity.setKey(exam.getId().toString());
+//        opportunity.setOppId(oppId.toString()); //TODO: Create oppId - auto-incremented Long ID
+        opportunity.setStartDate(expandableExam.getStartedAt().toString()); //TODO: Verify date format
+        opportunity.setStatus(exam.getStatus().getCode());
+        opportunity.setOpportunity(exam.getAttempts());
+        opportunity.setStatusDate(JaxbMapperUtils.convertInstantToGregorianCalendar(exam.getStartedAt()));
+        opportunity.setDateCompleted(expandableExam.getCompletedAt().toString()); //TODO: Verify date format
+        opportunity.setPauseCount(exam.getRestartsAndResumptions());
+        opportunity.setItemCount(expandableExam.getExamItems().size());
+        opportunity.setFtCount(expandableExam.getExamItems().stream()
+            .filter(ExamItem::isFieldTest)
+            .count());
+        opportunity.setAbnormalStarts(exam.getAbnormalStarts());
+        opportunity.setGracePeriodRestarts(exam.getResumptions());
+        opportunity.setTaId(session.getProctorEmail());
+        opportunity.setTaName(session.getProctorName());
+        opportunity.setSessionId(session.getId().toString());
+        opportunity.setWindowId(exam.getAssessmentWindowId());
+//        opportunity.setWindowOpportunity(); TODO: Add windowOpportunity to ExpandableExam
+        opportunity.setAdministrationCondition(
+            exam.getStatus().getCode().equalsIgnoreCase(ExamStatusCode.STATUS_INVALIDATED)
+                ? ADMINISTRATION_CONDITION_INVALIDATED
+                : "");
+        opportunity.setDateForceCompleted(expandableExam.getForceCompletedAt().toString()); //TODO: Verify date format
+        opportunity.setClientName(exam.getClientName());
+        opportunity.setAssessmentParticipantSessionPlatformUserAgent(exam.getBrowserUserAgent());
+//        opportunity.setEffectiveDate(); TODO: Add effectiveDate to ExpandableExam
+
+        mapExamSegmentsToOpportunity(expandableExam.getExamSegments(), opportunity.getSegment());
+        mapExamAccommodationsToOpportunity(expandableExam.getExamAccommodations(),  opportunity.getAccommodation());
+
+        // Map all of the assessment items with the item id as the map's key
+        final Map<String, Item> assessmentItems = assessment.getSegments().stream()
+            .flatMap(segment -> segment.getItems().stream())
+            .collect(Collectors.toMap(Item::getId, Function.identity()));
+
+        mapExamItemsAndResponsesToOpportunity(expandableExam, opportunity.getItem(), assessmentItems);
+
+
+        return opportunity;
+    }
+
+    private static void mapExamItemsAndResponsesToOpportunity(final ExpandableExam expandableExam,
+                                                              final List<TDSReport.Opportunity.Item> opportunityItems,
+                                                              final Map<String, Item> assessmentItems) {
+
+        for (ExamItem examItem : expandableExam.getExamItems()) {
+            ExamPage examPage = expandableExam.getExamPages().stream()
+                .filter(page -> page.getId().equals(examItem.getExamPageId()))
+                .findFirst().get();
+            TDSReport.Opportunity.Item opportunityItem = new TDSReport.Opportunity.Item();
+            Item assessmentItem = assessmentItems.get(examItem.getItemKey());
+
+            opportunityItem.setPosition(examItem.getPosition());
+            // Find the segmentId by joining on the page
+            opportunityItem.setSegmentId(examPage.getSegmentId());
+            opportunityItem.setBankKey(examItem.getAssessmentItemBankKey());
+            opportunityItem.setKey(examItem.getAssessmentItemKey());
+//            opportunityItem.setClientId(examItem.getClientId()); TODO: add clientId to ExamItems
+            opportunityItem.setOperational(examItem.isFieldTest() ? (short) 0 : 1);
+//            opportunityItem.setIsSelected(examItem.isSelected ? (short) 1 : 0); TODO: add isSelected to ExamItem
+            opportunityItem.setFormat(examItem.getItemType());
+
+            // If the item response has a score, set it. Otherwise default to -1
+            if (examItem.getResponse().isPresent()) {
+                ExamItemResponse examItemResponse = examItem.getResponse().get();
+
+//                opportunityItem.setResponseDuration(response.getDuration()); TODO: Get page duration and divide by # of items in page
+                ExamItemResponse itemResponse = examItem.getResponse().get();
+                TDSReport.Opportunity.Item.Response response = new TDSReport.Opportunity.Item.Response();
+                // See ReportingDLL [991] - need to wrap response in CDATA element if MC or MS type
+                final String content =
+                    (examItem.getItemType().equalsIgnoreCase("MC") || examItem.getItemType().equalsIgnoreCase("MS"))
+                        ? "<![CDATA[ " + itemResponse.getResponse() + " ]]>"
+                        : itemResponse.getResponse();
+                response.setContent(content);
+                response.setDate(JaxbMapperUtils.convertInstantToGregorianCalendar(itemResponse.getCreatedAt()));
+                opportunityItem.setResponse(response);
+
+                if (examItemResponse.getScore().isPresent()) {
+                    ExamItemResponseScore score = examItemResponse.getScore().get();
+                    final String scoreString = String.valueOf(score.getScore());
+                    final String scoreStatus = score.getScoringStatus().toString();
+
+                    opportunityItem.setScore(scoreString);
+                    opportunityItem.setScoreStatus(scoreStatus);
+
+                    ScoreInfoType scoreInfo = new ScoreInfoType();
+                    // Add the <ScoreRationale>
+                    ScoreInfoType.ScoreRationale rationale = new ScoreInfoType.ScoreRationale();
+                    rationale.getContent().add(score.getScoringRationale());
+                    scoreInfo.setScoreRationale(rationale);
+                    scoreInfo.setScorePoint(scoreString);
+//                scoreInfo.setMaxScore(examItem.getMaxScore()); TODO: Add max score to ExamItem
+                    if (score.getScoringDimensions().isPresent()) {
+                        scoreInfo.setScoreDimension(score.getScoringDimensions().get());
+                    }
+                    scoreInfo.setScoreStatus(scoreStatus);
+                    opportunityItem.setScoreInfo(scoreInfo);
+                } else {
+                    opportunityItem.setScore(String.valueOf(ITEM_NOT_SCORED_VALUE));
+                }
+            } else {
+                opportunityItem.setScore(String.valueOf(ITEM_NOT_SCORED_VALUE));
+            }
+
+            opportunityItem.setAdminDate(JaxbMapperUtils.convertInstantToGregorianCalendar(examPage.getCreatedAt()));
+//            opportunityItem.setNumberVisits(examItem.getUpdateCount()); TODO: add updateCount to ExamItem
+//            opportunityItem.setMimeType(examItem.getMimeType()); TODO: get MimeType from Assessment Item
+            opportunityItem.setStrand(assessmentItem.getStrand());
+//            opportunityItem.setContentLevel(examItem.getContentLevel()); TODO: add contentLevel to ExamItem
+            opportunityItem.setPageNumber(examPage.getPagePosition());
+//            opportunityItem.setPageVisits(examPage.getPageVisits()); TODO: add pageVisits to ExamPage ?
+//            opportunityItem.setPageTime(examPage.getPageTime()); TODO: add pageTime ExamPage
+//            opportunityItem.setDropped((examItem)); TODO: get notForScoring from itembank
+            opportunityItems.add(opportunityItem);
+        }
+    }
+
+    private static void mapExamAccommodationsToOpportunity(final List<ExamAccommodation> examAccommodations,
+                                                           final List<TDSReport.Opportunity.Accommodation> opportunityAccommodations) {
+        for (ExamAccommodation examAccommodation : examAccommodations) {
+            TDSReport.Opportunity.Accommodation opportunityAccommodation = new TDSReport.Opportunity.Accommodation();
+            opportunityAccommodation.setType(examAccommodation.getType());
+            opportunityAccommodation.setValue(examAccommodation.getValue());
+            opportunityAccommodation.setCode(examAccommodation.getCode());
+            opportunityAccommodation.setSegment(examAccommodation.getSegmentPosition());
+            opportunityAccommodations.add(opportunityAccommodation);
+        }
+    }
+
+    private static void mapExamSegmentsToOpportunity(final List<ExamSegment> examSegments, final List<TDSReport.Opportunity.Segment> opportunitySegments) {
+        for (ExamSegment examSegment : examSegments) {
+            TDSReport.Opportunity.Segment opportunitySegment = new TDSReport.Opportunity.Segment();
+            opportunitySegment.setId(examSegment.getSegmentId());
+            opportunitySegment.setPosition((short)examSegment.getSegmentPosition());
+            opportunitySegment.setFormKey(examSegment.getFormKey());
+            opportunitySegment.setFormId(examSegment.getFormId());
+            opportunitySegment.setAlgorithm(examSegment.getAlgorithm().getType());
+            opportunitySegment.setAlgorithmVersion(DEFAULT_ALGORITHM_VERSION);
+            opportunitySegments.add(opportunitySegment);
+        }
+    }
+}

--- a/src/main/java/tds/exam/results/mappers/OpportunityMapper.java
+++ b/src/main/java/tds/exam/results/mappers/OpportunityMapper.java
@@ -2,7 +2,6 @@ package tds.exam.results.mappers;
 
 import org.springframework.stereotype.Component;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -19,32 +18,34 @@ import tds.exam.ExamPage;
 import tds.exam.ExamSegment;
 import tds.exam.ExamStatusCode;
 import tds.exam.ExpandableExam;
+import tds.exam.results.mappers.utils.JaxbMapperUtils;
 import tds.exam.results.trt.ScoreInfoType;
 import tds.exam.results.trt.TDSReport;
 import tds.session.Session;
 
-import tds.exam.results.mappers.utils.JaxbMapperUtils;
-
 /**
  * A class used for mapping a {@link tds.exam.results.trt.TDSReport.Opportunity} object from Exam and Session data
  */
-@Component
 public class OpportunityMapper {
     private static final String ADMINISTRATION_CONDITION_INVALIDATED = "IN";
     private static final float ITEM_NOT_SCORED_VALUE = -1;
     private static final String DEFAULT_ALGORITHM_VERSION = "0";
+    private static final String EXAM_DATABASE_NAME = "exam";
 
     public static TDSReport.Opportunity mapOpportunity(final ExpandableExam expandableExam, final Session session,
                                                        final Assessment assessment) {
         final Exam exam = expandableExam.getExam();
         TDSReport.Opportunity opportunity = new TDSReport.Opportunity();
         opportunity.setKey(exam.getId().toString());
+        opportunity.setDatabase(EXAM_DATABASE_NAME);
 //        opportunity.setOppId(oppId.toString()); //TODO: Create oppId - auto-incremented Long ID
-        opportunity.setStartDate(expandableExam.getStartedAt().toString()); //TODO: Verify date format
+        opportunity.setStartDate(exam.getStartedAt().toString()); //TODO: Verify date format
         opportunity.setStatus(exam.getStatus().getCode());
         opportunity.setOpportunity(exam.getAttempts());
         opportunity.setStatusDate(JaxbMapperUtils.convertInstantToGregorianCalendar(exam.getStartedAt()));
-        opportunity.setDateCompleted(expandableExam.getCompletedAt().toString()); //TODO: Verify date format
+        opportunity.setDateCompleted(exam.getCompletedAt() != null
+            ? exam.getCompletedAt().toString()
+            : null); //TODO: Verify date format
         opportunity.setPauseCount(exam.getRestartsAndResumptions());
         opportunity.setItemCount(expandableExam.getExamItems().size());
         opportunity.setFtCount(expandableExam.getExamItems().stream()
@@ -61,7 +62,9 @@ public class OpportunityMapper {
             exam.getStatus().getCode().equalsIgnoreCase(ExamStatusCode.STATUS_INVALIDATED)
                 ? ADMINISTRATION_CONDITION_INVALIDATED
                 : "");
-        opportunity.setDateForceCompleted(expandableExam.getForceCompletedAt().toString()); //TODO: Verify date format
+        opportunity.setDateForceCompleted(expandableExam.getForceCompletedAt() != null
+            ? expandableExam.getForceCompletedAt().toString()
+            : null); //TODO: Verify date format
         opportunity.setClientName(exam.getClientName());
         opportunity.setAssessmentParticipantSessionPlatformUserAgent(exam.getBrowserUserAgent());
 //        opportunity.setEffectiveDate(); TODO: Add effectiveDate to ExpandableExam
@@ -72,10 +75,9 @@ public class OpportunityMapper {
         // Map all of the assessment items with the item id as the map's key
         final Map<String, Item> assessmentItems = assessment.getSegments().stream()
             .flatMap(segment -> segment.getItems().stream())
-            .collect(Collectors.toMap(Item::getId, Function.identity()));
+            .collect(Collectors.toMap(Item::getId, Function.identity(), (item1, item2) -> item1));
 
         mapExamItemsAndResponsesToOpportunity(expandableExam, opportunity.getItem(), assessmentItems);
-
 
         return opportunity;
     }
@@ -83,23 +85,31 @@ public class OpportunityMapper {
     private static void mapExamItemsAndResponsesToOpportunity(final ExpandableExam expandableExam,
                                                               final List<TDSReport.Opportunity.Item> opportunityItems,
                                                               final Map<String, Item> assessmentItems) {
-
         for (ExamItem examItem : expandableExam.getExamItems()) {
-            ExamPage examPage = expandableExam.getExamPages().stream()
+            // find the page for this exam item - this should never be "empty"
+            final ExamPage examPage = expandableExam.getExamPages().stream()
                 .filter(page -> page.getId().equals(examItem.getExamPageId()))
                 .findFirst().get();
             TDSReport.Opportunity.Item opportunityItem = new TDSReport.Opportunity.Item();
             Item assessmentItem = assessmentItems.get(examItem.getItemKey());
 
             opportunityItem.setPosition(examItem.getPosition());
-            // Find the segmentId by joining on the page
             opportunityItem.setSegmentId(examPage.getSegmentId());
             opportunityItem.setBankKey(examItem.getAssessmentItemBankKey());
             opportunityItem.setKey(examItem.getAssessmentItemKey());
-//            opportunityItem.setClientId(examItem.getClientId()); TODO: add clientId to ExamItems
+            opportunityItem.setClientId(assessmentItem.getClientId());
             opportunityItem.setOperational(examItem.isFieldTest() ? (short) 0 : 1);
-//            opportunityItem.setIsSelected(examItem.isSelected ? (short) 1 : 0); TODO: add isSelected to ExamItem
             opportunityItem.setFormat(examItem.getItemType());
+            opportunityItem.setAdminDate(JaxbMapperUtils.convertInstantToGregorianCalendar(examPage.getCreatedAt()));
+//            opportunityItem.setNumberVisits(examItem.getUpdateCount()); TODO: add updateCount to ExamItem
+            opportunityItem.setMimeType(assessmentItem.getMimeType());
+            opportunityItem.setStrand(assessmentItem.getStrand());
+            opportunityItem.setContentLevel(assessmentItem.getContentLevel());
+            opportunityItem.setPageNumber(examPage.getPagePosition());
+//            opportunityItem.setPageVisits(examPage.getPageVisits()); TODO: add pageVisits to ExamPage
+//            opportunityItem.setPageTime(examPage.getPageTime()); TODO: add pageTime ExamPage
+            opportunityItem.setDropped(assessmentItem.isNotForScoring() ? (short) 1 : 0);
+            opportunityItems.add(opportunityItem);
 
             // If the item response has a score, set it. Otherwise default to -1
             if (examItem.getResponse().isPresent()) {
@@ -107,6 +117,7 @@ public class OpportunityMapper {
 
 //                opportunityItem.setResponseDuration(response.getDuration()); TODO: Get page duration and divide by # of items in page
                 ExamItemResponse itemResponse = examItem.getResponse().get();
+                opportunityItem.setIsSelected(itemResponse.isSelected() ? (short) 1 : 0);
                 TDSReport.Opportunity.Item.Response response = new TDSReport.Opportunity.Item.Response();
                 // See ReportingDLL [991] - need to wrap response in CDATA element if MC or MS type
                 final String content =
@@ -121,39 +132,29 @@ public class OpportunityMapper {
                     ExamItemResponseScore score = examItemResponse.getScore().get();
                     final String scoreString = String.valueOf(score.getScore());
                     final String scoreStatus = score.getScoringStatus().toString();
-
-                    opportunityItem.setScore(scoreString);
-                    opportunityItem.setScoreStatus(scoreStatus);
-
+                    // <ScoreInfo> element
                     ScoreInfoType scoreInfo = new ScoreInfoType();
-                    // Add the <ScoreRationale>
+                    // Add the child  <ScoreRationale>
                     ScoreInfoType.ScoreRationale rationale = new ScoreInfoType.ScoreRationale();
                     rationale.getContent().add(score.getScoringRationale());
                     scoreInfo.setScoreRationale(rationale);
                     scoreInfo.setScorePoint(scoreString);
-//                scoreInfo.setMaxScore(examItem.getMaxScore()); TODO: Add max score to ExamItem
+                    scoreInfo.setMaxScore(String.valueOf(assessmentItem.getMaxScore()));
+                    scoreInfo.setScoreStatus(scoreStatus);
+
                     if (score.getScoringDimensions().isPresent()) {
                         scoreInfo.setScoreDimension(score.getScoringDimensions().get());
                     }
-                    scoreInfo.setScoreStatus(scoreStatus);
+
                     opportunityItem.setScoreInfo(scoreInfo);
+                    opportunityItem.setScore(scoreString);
+                    opportunityItem.setScoreStatus(scoreStatus);
                 } else {
                     opportunityItem.setScore(String.valueOf(ITEM_NOT_SCORED_VALUE));
                 }
             } else {
                 opportunityItem.setScore(String.valueOf(ITEM_NOT_SCORED_VALUE));
             }
-
-            opportunityItem.setAdminDate(JaxbMapperUtils.convertInstantToGregorianCalendar(examPage.getCreatedAt()));
-//            opportunityItem.setNumberVisits(examItem.getUpdateCount()); TODO: add updateCount to ExamItem
-//            opportunityItem.setMimeType(examItem.getMimeType()); TODO: get MimeType from Assessment Item
-            opportunityItem.setStrand(assessmentItem.getStrand());
-//            opportunityItem.setContentLevel(examItem.getContentLevel()); TODO: add contentLevel to ExamItem
-            opportunityItem.setPageNumber(examPage.getPagePosition());
-//            opportunityItem.setPageVisits(examPage.getPageVisits()); TODO: add pageVisits to ExamPage ?
-//            opportunityItem.setPageTime(examPage.getPageTime()); TODO: add pageTime ExamPage
-//            opportunityItem.setDropped((examItem)); TODO: get notForScoring from itembank
-            opportunityItems.add(opportunityItem);
         }
     }
 

--- a/src/main/java/tds/exam/results/mappers/TestMapper.java
+++ b/src/main/java/tds/exam/results/mappers/TestMapper.java
@@ -1,0 +1,37 @@
+package tds.exam.results.mappers;
+
+import tds.assessment.Assessment;
+import tds.exam.results.trt.TDSReport;
+
+/**
+ * A class used for mapping a {@link tds.exam.results.trt.TDSReport.Test} object from {@link tds.assessment.Assessment} data
+ */
+public class TestMapper {
+    private final static String TEST_MODE_ONLINE = "online";
+
+    public static TDSReport.Test mapTest(final Assessment assessment) {
+        //TODO: Populate this assessment data
+        TDSReport.Test test = new TDSReport.Test();
+        test.setName(assessment.getKey());
+        test.setSubject(assessment.getSubject());
+        test.setTestId(assessment.getAssessmentId());
+        // Simply select the first bank key from any item (See ReportingDLL line [1321]
+        final Long bankKey = assessment.getSegments().get(0).getItems().stream()
+            .map(item -> Long.parseLong(parseBankKeyFromId(item.getId())))
+            .findFirst().get();
+
+        test.setBankKey(bankKey);
+//        test.setHandScoreProject(assessment.getHandScoredProject());
+//        test.setContract(assessment.getContract());
+        test.setMode(TEST_MODE_ONLINE);
+//        test.setGrade(assessment.getGrade());
+//        test.setAssessmentType(assessment.getType());
+//        test.setAcademicYear(assessment.getAcademicYear());
+//        test.setAssessmentVersion(assessment.getVersion());
+        return test;
+    }
+
+    private static String parseBankKeyFromId(final String itemId) {
+        return itemId.split("-")[0];
+    }
+}

--- a/src/main/java/tds/exam/results/mappers/TestMapper.java
+++ b/src/main/java/tds/exam/results/mappers/TestMapper.java
@@ -15,7 +15,7 @@ public class TestMapper {
         test.setName(assessment.getKey());
         test.setSubject(assessment.getSubject());
         test.setTestId(assessment.getAssessmentId());
-        // Simply select the first bank key from any item (See ReportingDLL line [1321]
+        // Simply select the first bank key from any item (See ReportingDLL line [1321])
         final Long bankKey = assessment.getSegments().get(0).getItems().stream()
             .map(item -> Long.parseLong(parseBankKeyFromId(item.getId())))
             .findFirst().get();
@@ -32,6 +32,10 @@ public class TestMapper {
     }
 
     private static String parseBankKeyFromId(final String itemId) {
+        if (!itemId.contains("-")) {
+            throw new IllegalArgumentException(String.format("Could not parse bank key out of the itemId '%s'.", itemId));
+        }
+
         return itemId.split("-")[0];
     }
 }

--- a/src/main/java/tds/exam/results/mappers/utils/JaxbMapperUtils.java
+++ b/src/main/java/tds/exam/results/mappers/utils/JaxbMapperUtils.java
@@ -1,0 +1,18 @@
+package tds.exam.results.mappers.utils;
+
+import com.sun.org.apache.xerces.internal.jaxp.datatype.XMLGregorianCalendarImpl;
+import org.joda.time.Instant;
+
+import javax.xml.datatype.XMLGregorianCalendar;
+import java.util.GregorianCalendar;
+
+/**
+ * Utility class for mapping performance domain objects to JAXB objects
+ */
+public class JaxbMapperUtils {
+    public static XMLGregorianCalendar convertInstantToGregorianCalendar(final Instant instant) {
+        final GregorianCalendar calendar = new GregorianCalendar(instant.getZone().toTimeZone());
+        calendar.setTimeInMillis(instant.getMillis());
+        return new XMLGregorianCalendarImpl(calendar);
+    }
+}

--- a/src/main/java/tds/exam/results/repositories/AssessmentRepository.java
+++ b/src/main/java/tds/exam/results/repositories/AssessmentRepository.java
@@ -1,0 +1,17 @@
+package tds.exam.results.repositories;
+
+import tds.assessment.Assessment;
+
+/**
+ * Repository for interacting with the Assessment Service
+ */
+public interface AssessmentRepository {
+    /**
+     * Retrieves an {@link tds.assessment.Assessment} from the assessment service by the assessment key
+     *
+     * @param clientName the current envrionment's client name
+     * @param key        the key of the {@link tds.assessment.Assessment}
+     * @return the fully populated {@link tds.assessment.Assessment}\
+     */
+    Assessment findAssessment(final String clientName, final String key);
+}

--- a/src/main/java/tds/exam/results/repositories/ExamRepository.java
+++ b/src/main/java/tds/exam/results/repositories/ExamRepository.java
@@ -7,7 +7,7 @@ import tds.exam.ExpandableExam;
 /**
  * A repository for fetching an {@link tds.exam.ExpandableExam} from the exam service
  */
-public interface ExpandableExamRepository {
+public interface ExamRepository {
     /**
      * Finds an {@link tds.exam.ExpandableExam} for the given examId
      *

--- a/src/main/java/tds/exam/results/repositories/ExpandableExamRepository.java
+++ b/src/main/java/tds/exam/results/repositories/ExpandableExamRepository.java
@@ -1,0 +1,18 @@
+package tds.exam.results.repositories;
+
+import java.util.UUID;
+
+import tds.exam.ExpandableExam;
+
+/**
+ * A repository for fetching an {@link tds.exam.ExpandableExam} from the exam service
+ */
+public interface ExpandableExamRepository {
+    /**
+     * Finds an {@link tds.exam.ExpandableExam} for the given examId
+     *
+     * @param examId The id of the exam to fetch
+     * @return The fully populated {@link tds.exam.ExpandableExam}
+     */
+    ExpandableExam findExpandableExam(final UUID examId);
+}

--- a/src/main/java/tds/exam/results/repositories/SessionRepository.java
+++ b/src/main/java/tds/exam/results/repositories/SessionRepository.java
@@ -1,0 +1,18 @@
+package tds.exam.results.repositories;
+
+import java.util.UUID;
+
+import tds.session.Session;
+
+/**
+ * A repository used for fetching {@link tds.session.Session} data
+ */
+public interface SessionRepository {
+    /**
+     * Finds a session for the given sessionId
+     *
+     * @param sessionId The id of the session to fetch
+     * @return The {@link tds.session.Session} with the given id
+     */
+    Session findSessionById(final UUID sessionId);
+}

--- a/src/main/java/tds/exam/results/repositories/impl/RemoteAssessmentRepository.java
+++ b/src/main/java/tds/exam/results/repositories/impl/RemoteAssessmentRepository.java
@@ -1,0 +1,48 @@
+package tds.exam.results.repositories.impl;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import tds.assessment.Assessment;
+import tds.exam.results.configuration.ExamResultsTransmitterServiceProperties;
+import tds.exam.results.repositories.AssessmentRepository;
+
+@Repository
+public class RemoteAssessmentRepository implements AssessmentRepository {
+    private final RestTemplate restTemplate;
+    private final ExamResultsTransmitterServiceProperties properties;
+
+    @Autowired
+    public RemoteAssessmentRepository(final RestTemplate restTemplate,
+                                      final ExamResultsTransmitterServiceProperties properties) {
+        this.restTemplate = restTemplate;
+        this.properties = properties;
+    }
+
+    @Override
+    public Assessment findAssessment(final String clientName, final String key) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Accept", MediaType.APPLICATION_JSON_VALUE);
+        HttpEntity<?> requestHttpEntity = new HttpEntity<>(headers);
+        ResponseEntity<Assessment> responseEntity;
+
+        UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(String.format("%s/%s/assessments/%s", properties.getAssessmentUrl(), clientName, key));
+
+        responseEntity = restTemplate.exchange(
+            builder.build().toUri(),
+            HttpMethod.GET,
+            requestHttpEntity,
+            new ParameterizedTypeReference<Assessment>() {
+            });
+
+        return responseEntity.getBody();
+    }
+}

--- a/src/main/java/tds/exam/results/repositories/impl/RemoteExamRepository.java
+++ b/src/main/java/tds/exam/results/repositories/impl/RemoteExamRepository.java
@@ -1,0 +1,63 @@
+package tds.exam.results.repositories.impl;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.UUID;
+
+import tds.exam.ExpandableExam;
+import tds.exam.ExpandableExamAttributes;
+import tds.exam.results.configuration.ExamResultsTransmitterServiceProperties;
+import tds.exam.results.repositories.ExamRepository;
+
+import static tds.exam.results.configuration.SupportApplicationConfiguration.EXAM_APP_CONTEXT;
+
+@Repository
+public class RemoteExamRepository implements ExamRepository {
+    private final RestTemplate restTemplate;
+    private final ExamResultsTransmitterServiceProperties properties;
+
+    @Autowired
+    public RemoteExamRepository(final RestTemplate restTemplate,
+                                final ExamResultsTransmitterServiceProperties properties) {
+        this.restTemplate = restTemplate;
+        this.properties = properties;
+    }
+
+    @Override
+    public ExpandableExam findExpandableExam(final UUID examId) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Accept", MediaType.APPLICATION_JSON_VALUE);
+        HttpEntity<?> requestHttpEntity = new HttpEntity<>(headers);
+        ResponseEntity<ExpandableExam> responseEntity;
+
+        UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(String.format("%s/%s/%s/expandable",
+                properties.getExamUrl(),
+                EXAM_APP_CONTEXT,
+                examId))
+            .queryParam("expandableAttribute", ExpandableExamAttributes.EXAM_SEGMENTS)
+            .queryParam("expandableAttribute", ExpandableExamAttributes.EXAM_ACCOMMODATIONS)
+            .queryParam("expandableAttribute", ExpandableExamAttributes.EXAM_NOTES)
+            .queryParam("expandableAttribute", ExpandableExamAttributes.EXAMINEE_ATTRIBUTES_AND_RELATIONSHIPS)
+            .queryParam("expandableAttribute", ExpandableExamAttributes.EXAM_PAGE_AND_ITEMS)
+            .queryParam("expandableAttribute", ExpandableExamAttributes.EXAM_STATUS_DATES);
+
+
+        responseEntity = restTemplate.exchange(
+            builder.build().toUri(),
+            HttpMethod.GET,
+            requestHttpEntity,
+            new ParameterizedTypeReference<ExpandableExam>() {
+            });
+
+        return responseEntity.getBody();
+    }
+}

--- a/src/main/java/tds/exam/results/repositories/impl/RemoteSessionRepository.java
+++ b/src/main/java/tds/exam/results/repositories/impl/RemoteSessionRepository.java
@@ -1,0 +1,36 @@
+package tds.exam.results.repositories.impl;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.UUID;
+
+import tds.exam.results.configuration.ExamResultsTransmitterServiceProperties;
+import tds.exam.results.repositories.SessionRepository;
+import tds.session.Session;
+
+import static tds.exam.results.configuration.SupportApplicationConfiguration.SESSION_APP_CONTEXT;
+
+@Repository
+public class RemoteSessionRepository implements SessionRepository {
+    private final RestTemplate restTemplate;
+    private final ExamResultsTransmitterServiceProperties properties;
+
+    @Autowired
+    public RemoteSessionRepository(final RestTemplate restTemplate, final ExamResultsTransmitterServiceProperties properties) {
+        this.restTemplate = restTemplate;
+        this.properties = properties;
+    }
+
+    @Override
+    public Session findSessionById(final UUID sessionId) {
+        UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(String.format("%s/%s/%s",
+            properties.getSessionUrl(),
+            SESSION_APP_CONTEXT,
+            sessionId));
+
+        return restTemplate.getForObject(builder.build().toUri(), Session.class);
+    }
+}

--- a/src/main/java/tds/exam/results/services/AssessmentService.java
+++ b/src/main/java/tds/exam/results/services/AssessmentService.java
@@ -1,0 +1,17 @@
+package tds.exam.results.services;
+
+import tds.assessment.Assessment;
+
+/**
+ * Service for interacting with a remote assessment service
+ */
+public interface AssessmentService {
+    /**
+     * Retrieves an {@link tds.assessment.Assessment} from the assessment service by the assessment key
+     *
+     * @param clientName the current envrionment's client name
+     * @param key        the key of the {@link tds.assessment.Assessment}
+     * @return the fully populated {@link tds.assessment.Assessment}\
+     */
+    Assessment findAssessment(final String clientName, final String key);
+}

--- a/src/main/java/tds/exam/results/services/ExamResultsService.java
+++ b/src/main/java/tds/exam/results/services/ExamResultsService.java
@@ -11,8 +11,18 @@ import java.io.IOException;
 import java.util.UUID;
 
 /**
- * Created by emunoz on 4/3/17.
+ * A service responsible for fetching the necessary data and constructing the TDSReport TRT object
  */
 public interface ExamResultsService {
+    /**
+     * Constructs the {@link tds.exam.results.trt.TDSReport} object with data fetched from Exam, Session, and Assessment
+     * services.
+     *
+     * @param examId The id of the exam for the {@link tds.exam.results.trt.TDSReport}
+     * @return The fully populated {@link tds.exam.results.trt.TDSReport} object
+     * @throws JAXBException
+     * @throws SAXException
+     * @throws IOException
+     */
     TDSReport findExamResults(UUID examId) throws JAXBException, SAXException, IOException;
 }

--- a/src/main/java/tds/exam/results/services/ExamResultsService.java
+++ b/src/main/java/tds/exam/results/services/ExamResultsService.java
@@ -1,0 +1,18 @@
+package tds.exam.results.services;
+
+import org.xml.sax.SAXException;
+
+import javax.xml.bind.JAXBException;
+
+import tds.exam.results.services.impl.ExamResultsServiceImpl;
+import tds.exam.results.trt.TDSReport;
+
+import java.io.IOException;
+import java.util.UUID;
+
+/**
+ * Created by emunoz on 4/3/17.
+ */
+public interface ExamResultsService {
+    TDSReport findExamResults(UUID examId) throws JAXBException, SAXException, IOException;
+}

--- a/src/main/java/tds/exam/results/services/ExamService.java
+++ b/src/main/java/tds/exam/results/services/ExamService.java
@@ -1,0 +1,18 @@
+package tds.exam.results.services;
+
+import java.util.UUID;
+
+import tds.exam.ExpandableExam;
+
+/**
+ * Service for interacting with a remote exam service
+ */
+public interface ExamService {
+    /**
+     * Fetches an {@link tds.exam.ExpandableExam} with the given exam id.
+     *
+     * @param examId The id of the exam to fetch
+     * @return The fully-populated {@link tds.exam.ExpandableExam}
+     */
+    ExpandableExam findExpandableExam(final UUID examId);
+}

--- a/src/main/java/tds/exam/results/services/SessionService.java
+++ b/src/main/java/tds/exam/results/services/SessionService.java
@@ -1,0 +1,18 @@
+package tds.exam.results.services;
+
+import java.util.UUID;
+
+import tds.session.Session;
+
+/**
+ * Service for interacting with a remote session service
+ */
+public interface SessionService {
+    /**
+     * Finds a session for the given sessionId
+     *
+     * @param sessionId The id of the session to fetch
+     * @return The {@link tds.session.Session} with the given id
+     */
+    Session findSessionById(final UUID sessionId);
+}

--- a/src/main/java/tds/exam/results/services/impl/AssessmentServiceImpl.java
+++ b/src/main/java/tds/exam/results/services/impl/AssessmentServiceImpl.java
@@ -1,0 +1,26 @@
+package tds.exam.results.services.impl;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+import tds.assessment.Assessment;
+import tds.common.cache.CacheType;
+import tds.exam.results.repositories.AssessmentRepository;
+import tds.exam.results.services.AssessmentService;
+
+@Service
+public class AssessmentServiceImpl implements AssessmentService {
+    private final AssessmentRepository assessmentRepository;
+
+    @Autowired
+    public AssessmentServiceImpl(final AssessmentRepository assessmentRepository) {
+        this.assessmentRepository = assessmentRepository;
+    }
+
+    @Override
+    @Cacheable(CacheType.LONG_TERM)
+    public Assessment findAssessment(final String clientName, final String key) {
+        return assessmentRepository.findAssessment(clientName, key);
+    }
+}

--- a/src/main/java/tds/exam/results/services/impl/ExamResultsServiceImpl.java
+++ b/src/main/java/tds/exam/results/services/impl/ExamResultsServiceImpl.java
@@ -28,6 +28,7 @@ import tds.exam.results.services.ExamResultsService;
 import tds.exam.results.services.ExamService;
 import tds.exam.results.services.SessionService;
 import tds.exam.results.trt.TDSReport;
+import tds.exam.results.validation.TDSReportValidator;
 import tds.session.Session;
 
 @Service
@@ -35,19 +36,17 @@ public class ExamResultsServiceImpl implements ExamResultsService {
     private final ExamService examService;
     private final SessionService sessionService;
     private final AssessmentService assessmentService;
-    private final JAXBContext contextObj;
+    private final TDSReportValidator tdsReportValidator;
 
     @Autowired
     public ExamResultsServiceImpl(final ExamService examService,
                                   final SessionService sessionService,
-                                  final AssessmentService assessmentService) throws JAXBException {
+                                  final AssessmentService assessmentService,
+                                  final TDSReportValidator tdsReportValidator) {
         this.examService = examService;
         this.sessionService = sessionService;
         this.assessmentService = assessmentService;
-
-        contextObj = JAXBContext.newInstance(TDSReport.class);
-        Marshaller marshallerObj = contextObj.createMarshaller();
-        marshallerObj.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
+        this.tdsReportValidator = tdsReportValidator;
     }
 
     @Override
@@ -63,18 +62,10 @@ public class ExamResultsServiceImpl implements ExamResultsService {
         report.setTest(TestMapper.mapTest(assessment));
         CommentMapper.mapComments(report.getComment(), expandableExam);
 
-        validateReport(report);
+        tdsReportValidator.validateReport(report);
 
         return report;
     }
 
-    private void validateReport(final TDSReport results) throws JAXBException, SAXException, IOException {
-        JAXBSource source = new JAXBSource(contextObj, results);
-        SchemaFactory sf = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
-        Schema schema = sf.newSchema(new File("src/main/xsd/TestResultsTransmissionFormat_Schema.xsd"));
 
-        Validator validator = schema.newValidator();
-        // TODO: Enable the validator once all "required" properties are added to Exam/Assessment
-//        validator.validate(source);
-    }
 }

--- a/src/main/java/tds/exam/results/services/impl/ExamResultsServiceImpl.java
+++ b/src/main/java/tds/exam/results/services/impl/ExamResultsServiceImpl.java
@@ -23,43 +23,40 @@ import tds.exam.results.mappers.CommentMapper;
 import tds.exam.results.mappers.ExamineeMapper;
 import tds.exam.results.mappers.OpportunityMapper;
 import tds.exam.results.mappers.TestMapper;
-import tds.exam.results.repositories.AssessmentRepository;
-import tds.exam.results.repositories.ExpandableExamRepository;
-import tds.exam.results.repositories.SessionRepository;
+import tds.exam.results.services.AssessmentService;
 import tds.exam.results.services.ExamResultsService;
+import tds.exam.results.services.ExamService;
+import tds.exam.results.services.SessionService;
 import tds.exam.results.trt.TDSReport;
 import tds.session.Session;
 
 @Service
 public class ExamResultsServiceImpl implements ExamResultsService {
-    private final ExpandableExamRepository expandableExamRepository;
-    private final SessionRepository sessionRepository;
-    private final AssessmentRepository assessmentRepository;
-
-    private JAXBContext contextObj = null;
+    private final ExamService examService;
+    private final SessionService sessionService;
+    private final AssessmentService assessmentService;
+    private final JAXBContext contextObj;
 
     @Autowired
-    public ExamResultsServiceImpl(final ExpandableExamRepository expandableExamRepository,
-                                  final SessionRepository sessionRepository,
-                                  final AssessmentRepository assessmentRepository) throws JAXBException {
-        this.expandableExamRepository = expandableExamRepository;
-        this.sessionRepository = sessionRepository;
-        this.assessmentRepository = assessmentRepository;
+    public ExamResultsServiceImpl(final ExamService examService,
+                                  final SessionService sessionService,
+                                  final AssessmentService assessmentService) throws JAXBException {
+        this.examService = examService;
+        this.sessionService = sessionService;
+        this.assessmentService = assessmentService;
 
-        JAXBContext contextObj = JAXBContext.newInstance(TDSReport.class);
+        contextObj = JAXBContext.newInstance(TDSReport.class);
         Marshaller marshallerObj = contextObj.createMarshaller();
         marshallerObj.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
-
     }
 
     @Override
     public TDSReport findExamResults(final UUID examId) throws SAXException, IOException, JAXBException {
-
         TDSReport report = new TDSReport();
-        ExpandableExam expandableExam = expandableExamRepository.findExpandableExam(examId);
-        Exam exam = expandableExam.getExam();
-        Session session = sessionRepository.findSessionById(exam.getSessionId());
-        Assessment assessment = assessmentRepository.findAssessment(exam.getClientName(), exam.getAssessmentKey());
+        final ExpandableExam expandableExam = examService.findExpandableExam(examId);
+        final Exam exam = expandableExam.getExam();
+        final Session session = sessionService.findSessionById(exam.getSessionId());
+        final Assessment assessment = assessmentService.findAssessment(exam.getClientName(), exam.getAssessmentKey());
 
         report.setOpportunity(OpportunityMapper.mapOpportunity(expandableExam, session, assessment));
         report.setExaminee(ExamineeMapper.mapExaminee(expandableExam));
@@ -71,13 +68,13 @@ public class ExamResultsServiceImpl implements ExamResultsService {
         return report;
     }
 
-    private void validateReport(final TDSReport report) throws JAXBException, SAXException, IOException {
-        JAXBSource source = new JAXBSource(contextObj, report);
+    private void validateReport(final TDSReport results) throws JAXBException, SAXException, IOException {
+        JAXBSource source = new JAXBSource(contextObj, results);
         SchemaFactory sf = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
-        Schema schema = sf.newSchema(new File("/xsd/TestResultsTransmissionFormat_Schema.xsd"));
+        Schema schema = sf.newSchema(new File("src/main/xsd/TestResultsTransmissionFormat_Schema.xsd"));
 
         Validator validator = schema.newValidator();
-//        validator.setErrorHandler(new MyErrorHandler());
-        validator.validate(source);
+        // TODO: Enable the validator once all "required" properties are added to Exam/Assessment
+//        validator.validate(source);
     }
 }

--- a/src/main/java/tds/exam/results/services/impl/ExamResultsServiceImpl.java
+++ b/src/main/java/tds/exam/results/services/impl/ExamResultsServiceImpl.java
@@ -1,0 +1,83 @@
+package tds.exam.results.services.impl;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.xml.sax.SAXException;
+
+import javax.xml.XMLConstants;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import javax.xml.bind.util.JAXBSource;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+import javax.xml.validation.Validator;
+import java.io.File;
+import java.io.IOException;
+import java.util.UUID;
+
+import tds.assessment.Assessment;
+import tds.exam.Exam;
+import tds.exam.ExpandableExam;
+import tds.exam.results.mappers.CommentMapper;
+import tds.exam.results.mappers.ExamineeMapper;
+import tds.exam.results.mappers.OpportunityMapper;
+import tds.exam.results.mappers.TestMapper;
+import tds.exam.results.repositories.AssessmentRepository;
+import tds.exam.results.repositories.ExpandableExamRepository;
+import tds.exam.results.repositories.SessionRepository;
+import tds.exam.results.services.ExamResultsService;
+import tds.exam.results.trt.TDSReport;
+import tds.session.Session;
+
+@Service
+public class ExamResultsServiceImpl implements ExamResultsService {
+    private final ExpandableExamRepository expandableExamRepository;
+    private final SessionRepository sessionRepository;
+    private final AssessmentRepository assessmentRepository;
+
+    private JAXBContext contextObj = null;
+
+    @Autowired
+    public ExamResultsServiceImpl(final ExpandableExamRepository expandableExamRepository,
+                                  final SessionRepository sessionRepository,
+                                  final AssessmentRepository assessmentRepository) throws JAXBException {
+        this.expandableExamRepository = expandableExamRepository;
+        this.sessionRepository = sessionRepository;
+        this.assessmentRepository = assessmentRepository;
+
+        JAXBContext contextObj = JAXBContext.newInstance(TDSReport.class);
+        Marshaller marshallerObj = contextObj.createMarshaller();
+        marshallerObj.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
+
+    }
+
+    @Override
+    public TDSReport findExamResults(final UUID examId) throws SAXException, IOException, JAXBException {
+
+        TDSReport report = new TDSReport();
+        ExpandableExam expandableExam = expandableExamRepository.findExpandableExam(examId);
+        Exam exam = expandableExam.getExam();
+        Session session = sessionRepository.findSessionById(exam.getSessionId());
+        Assessment assessment = assessmentRepository.findAssessment(exam.getClientName(), exam.getAssessmentKey());
+
+        report.setOpportunity(OpportunityMapper.mapOpportunity(expandableExam, session, assessment));
+        report.setExaminee(ExamineeMapper.mapExaminee(expandableExam));
+        report.setTest(TestMapper.mapTest(assessment));
+        CommentMapper.mapComments(report.getComment(), expandableExam);
+
+        validateReport(report);
+
+        return report;
+    }
+
+    private void validateReport(final TDSReport report) throws JAXBException, SAXException, IOException {
+        JAXBSource source = new JAXBSource(contextObj, report);
+        SchemaFactory sf = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+        Schema schema = sf.newSchema(new File("/xsd/TestResultsTransmissionFormat_Schema.xsd"));
+
+        Validator validator = schema.newValidator();
+//        validator.setErrorHandler(new MyErrorHandler());
+        validator.validate(source);
+    }
+}

--- a/src/main/java/tds/exam/results/services/impl/ExamServiceImpl.java
+++ b/src/main/java/tds/exam/results/services/impl/ExamServiceImpl.java
@@ -1,0 +1,25 @@
+package tds.exam.results.services.impl;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+import tds.exam.ExpandableExam;
+import tds.exam.results.repositories.ExamRepository;
+import tds.exam.results.services.ExamService;
+
+@Service
+public class ExamServiceImpl implements ExamService {
+    final ExamRepository examRepository;
+
+    @Autowired
+    public ExamServiceImpl(final ExamRepository examRepository) {
+        this.examRepository = examRepository;
+    }
+
+    @Override
+    public ExpandableExam findExpandableExam(final UUID examId) {
+        return examRepository.findExpandableExam(examId);
+    }
+}

--- a/src/main/java/tds/exam/results/services/impl/SessionServiceImpl.java
+++ b/src/main/java/tds/exam/results/services/impl/SessionServiceImpl.java
@@ -1,0 +1,25 @@
+package tds.exam.results.services.impl;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+import tds.exam.results.repositories.SessionRepository;
+import tds.exam.results.services.SessionService;
+import tds.session.Session;
+
+@Service
+public class SessionServiceImpl implements SessionService {
+    private final SessionRepository sessionRepository;
+
+    @Autowired
+    public SessionServiceImpl(final SessionRepository sessionRepository) {
+        this.sessionRepository = sessionRepository;
+    }
+
+    @Override
+    public Session findSessionById(final UUID sessionId) {
+        return sessionRepository.findSessionById(sessionId);
+    }
+}

--- a/src/main/java/tds/exam/results/validation/TDSReportValidator.java
+++ b/src/main/java/tds/exam/results/validation/TDSReportValidator.java
@@ -26,6 +26,7 @@ public class TDSReportValidator {
 
         try {
             SchemaFactory sf = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+            //TODO: Investigate loading this up via classloader/classpath
             Schema schema = sf.newSchema(new File("src/main/xsd/TestResultsTransmissionFormat_Schema.xsd"));
             validator = schema.newValidator();
         } catch (SAXException e) {

--- a/src/main/java/tds/exam/results/validation/TDSReportValidator.java
+++ b/src/main/java/tds/exam/results/validation/TDSReportValidator.java
@@ -12,7 +12,6 @@ import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Validator;
 import java.io.File;
-import java.io.IOException;
 
 import tds.exam.results.trt.TDSReport;
 
@@ -39,7 +38,7 @@ public class TDSReportValidator {
             JAXBSource source = new JAXBSource(jaxbContext, results);
 //             TODO: Enable the validator once all "required" properties are added to Exam/Assessment
 //            validator.validate(source);
-        } catch (SAXException | JAXBException | IOException e) {
+        } catch (JAXBException e) {
             throw new RuntimeException(e);
         }
     }

--- a/src/main/java/tds/exam/results/validation/TDSReportValidator.java
+++ b/src/main/java/tds/exam/results/validation/TDSReportValidator.java
@@ -1,0 +1,46 @@
+package tds.exam.results.validation;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.xml.sax.SAXException;
+
+import javax.xml.XMLConstants;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.util.JAXBSource;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+import javax.xml.validation.Validator;
+import java.io.File;
+import java.io.IOException;
+
+import tds.exam.results.trt.TDSReport;
+
+@Component
+public class TDSReportValidator {
+    private final JAXBContext jaxbContext;
+    private final Validator validator;
+
+    @Autowired
+    public TDSReportValidator(final JAXBContext jaxbContext) {
+        this.jaxbContext = jaxbContext;
+
+        try {
+            SchemaFactory sf = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+            Schema schema = sf.newSchema(new File("src/main/xsd/TestResultsTransmissionFormat_Schema.xsd"));
+            validator = schema.newValidator();
+        } catch (SAXException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void validateReport(final TDSReport results) {
+        try {
+            JAXBSource source = new JAXBSource(jaxbContext, results);
+//             TODO: Enable the validator once all "required" properties are added to Exam/Assessment
+//            validator.validate(source);
+        } catch (SAXException | JAXBException | IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/tds/exam/results/web/endpoints/ResultsController.java
+++ b/src/main/java/tds/exam/results/web/endpoints/ResultsController.java
@@ -1,16 +1,32 @@
 package tds.exam.results.web.endpoints;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
+
+import javax.xml.bind.JAXBException;
+
+import tds.exam.results.trt.TDSReport;
 
 import java.util.UUID;
 
+import tds.exam.results.services.ExamResultsService;
+
 @RestController
 public class ResultsController {
-    @GetMapping(value = "/{examId}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public String findExamResults(@PathVariable final UUID examId) {
-        return "test";
+    private final ExamResultsService examResultsService;
+
+    @Autowired
+    public ResultsController(final ExamResultsService examResultsService) {
+        this.examResultsService = examResultsService;
+    }
+
+    @GetMapping(value = "/{examId}", produces = MediaType.APPLICATION_XML_VALUE)
+    @ResponseBody
+    public TDSReport findExamResults(@PathVariable final UUID examId) throws JAXBException {
+        return examResultsService.findExamResults(examId);
     }
 }

--- a/src/main/java/tds/exam/results/web/endpoints/ResultsController.java
+++ b/src/main/java/tds/exam/results/web/endpoints/ResultsController.java
@@ -6,11 +6,13 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
+import org.xml.sax.SAXException;
 
 import javax.xml.bind.JAXBException;
 
 import tds.exam.results.trt.TDSReport;
 
+import java.io.IOException;
 import java.util.UUID;
 
 import tds.exam.results.services.ExamResultsService;
@@ -26,7 +28,7 @@ public class ResultsController {
 
     @GetMapping(value = "/{examId}", produces = MediaType.APPLICATION_XML_VALUE)
     @ResponseBody
-    public TDSReport findExamResults(@PathVariable final UUID examId) throws JAXBException {
+    public TDSReport findExamResults(@PathVariable final UUID examId) throws JAXBException, IOException, SAXException {
         return examResultsService.findExamResults(examId);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,3 +6,9 @@ server:
     io-threads: 64
     worker-threads: 512
     direct-buffers: true
+
+#Ports defined in TDS_Build:docker-compose.yml
+exam-results-transmitter-service:
+  session-url: http://localhost:32842
+  assessment-url: http://localhost:32841
+  exam-url: http://localhost:8081

--- a/src/main/xsd/TestResultsTransmissionFormat_Schema.xsd
+++ b/src/main/xsd/TestResultsTransmissionFormat_Schema.xsd
@@ -1,0 +1,362 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+<xs:element name="TDSReport">
+    <xs:complexType>
+        <xs:sequence>
+            <xs:element name="Test" minOccurs="1" maxOccurs="1">
+                <xs:complexType>
+                    <xs:attribute name="name" use="required"/>
+                    <xs:attribute name="subject" use="required"/>
+                    <xs:attribute name="testId" use="required"/>
+                    <xs:attribute name="bankKey" type="xs:unsignedInt"/>
+                    <xs:attribute name="contract"/>
+                    <xs:attribute name="mode" use="required">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:token">
+                                <xs:enumeration value="online"/>
+                                <xs:enumeration value="paper"/>
+                                <xs:enumeration value="scanned"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:attribute>
+                    <xs:attribute name="grade" use="required"/>
+                    <!-- not expected to be used for open source, but may be needed for internal purposes -->
+                    <xs:attribute name="handScoreProject" type="xs:unsignedInt"/>
+                    <!-- new fields requested for open source -->
+                    <xs:attribute name="assessmentType" use="required"/>
+                    <xs:attribute name="academicYear" type="xs:unsignedInt" use="required"/>
+                    <xs:attribute name="assessmentVersion"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Examinee" minOccurs="1" maxOccurs="1">
+                <xs:complexType>
+                    <xs:choice minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="ExamineeAttribute">
+                            <xs:complexType>
+                                <xs:attribute name="context" use="required" type="Context"/>
+                                <xs:attribute name="name" use="required"/>
+                                <xs:attribute name="value"/>
+                                <xs:attribute name="contextDate" use="required" type="xs:dateTime"/>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="ExamineeRelationship">
+                            <xs:complexType>
+                                <xs:attribute name="context" use="required" type="Context"/>
+                                <xs:attribute name="name" use="required"/>
+                                <xs:attribute name="entityKey" type="xs:unsignedLong"/>
+                                <xs:attribute name="value"/>
+                                <xs:attribute name="contextDate" use="required" type="xs:dateTime"/>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:choice>
+                    <!-- negative values are used by TDS for testing. -->
+                    <xs:attribute name="key" type="xs:long"/>
+                    <xs:attribute name="isDemo" type="Bit"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Opportunity" minOccurs="1" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence>
+                        <!-- note: DTD has minOccurs=1, but we could get an invalidation for a joined but 
+                                      not-started test; no seg will have been initialized in this case -->
+                        <xs:element name="Segment" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:attribute name="id" use="required"/>
+                                <xs:attribute name="position" use="required">
+                                    <xs:simpleType>
+                                        <xs:restriction base="xs:unsignedByte">
+                                            <xs:minInclusive value="1"/>
+                                        </xs:restriction>
+                                    </xs:simpleType>
+                                </xs:attribute>
+                                <xs:attribute name="formId"/>
+                                <xs:attribute name="formKey"/>
+                                <xs:attribute name="algorithm" use="required"/>
+                                <!-- new field requested for open source -->
+                                <xs:attribute name="algorithmVersion" use="required"/>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="Accommodation" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:attribute name="type" use="required"/>
+                                <xs:attribute name="value" use="required"/>
+                                <!-- DTD says implied, but this cannot be null -->
+                                <xs:attribute name="code" use="required"/>
+                                <!-- DTD says implied, but this will always be populated; 0 if not segment-oriented -->
+                                <xs:attribute name="segment" use="required">
+                                    <xs:simpleType>
+                                        <xs:restriction base="xs:unsignedInt">
+                                            <xs:minInclusive value="0"/>
+                                        </xs:restriction>
+                                    </xs:simpleType>
+                                </xs:attribute>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="Score" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:attribute name="measureOf" use="required"/>
+                                <xs:attribute name="measureLabel" use="required"/>
+                                <xs:attribute name="value" use="required"/>
+                                <xs:attribute name="standardError" type="NullableFloat" use="required"/>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="GenericVariable" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:attribute name="context" use="required"/>
+                                <xs:attribute name="name" use="required"/>
+                                <xs:attribute name="value" use="required"/>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="Item" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="Response" minOccurs="0" maxOccurs="1">
+                                        <xs:complexType mixed="true">
+                                            <xs:attribute name="date" type="xs:dateTime" use="required"/>
+                                            <xs:attribute name="type" use="required">
+                                                <xs:simpleType>
+                                                    <xs:restriction base="xs:token">
+                                                        <xs:enumeration value="value"/>
+                                                        <xs:enumeration value="reference"/>
+                                                        <xs:enumeration value=""/>
+                                                    </xs:restriction>
+                                                </xs:simpleType>
+                                            </xs:attribute>
+                                            <xs:attribute name="key"/>
+                                        </xs:complexType>
+                                    </xs:element>
+                                    <xs:element name="ScoreInfo" type="ScoreInfoType" minOccurs="0" maxOccurs="1"/>
+                                </xs:sequence>
+                                <xs:attribute name="position" use="required" type="xs:unsignedInt"/>
+                                <xs:attribute name="segmentId" use="required"/>
+                                <xs:attribute name="bankKey" use="required" type="xs:unsignedInt"/>
+                                <xs:attribute name="key" use="required" type="xs:unsignedInt"/>
+                                <xs:attribute name="operational" use="required" type="Bit"/>
+                                <xs:attribute name="isSelected" use="required" type="Bit"/>
+                                <xs:attribute name="format" use="required"/>
+                                <xs:attribute name="score" use="required" type="UFloatAllowNegativeOne"/>
+                                <!-- may not be set for unselected items, or may be set to NOTSCORED -->
+                                <xs:attribute name="scoreStatus">
+                                    <xs:simpleType>
+                                        <xs:restriction base="xs:token">
+                                            <xs:enumeration value="NOTSCORED"/>
+                                            <xs:enumeration value="SCORED"/>
+                                            <xs:enumeration value="WAITINGFORMACHINESCORE"/>
+                                            <xs:enumeration value="SCORINGERROR"/>
+                                            <!-- future -->
+                                            <xs:enumeration value="APPEALED"/>
+                                        </xs:restriction>
+                                    </xs:simpleType>
+                                </xs:attribute>
+                                <xs:attribute name="adminDate" use="required" type="xs:dateTime"/>
+                                <xs:attribute name="numberVisits" use="required" type="xs:unsignedInt"/>
+                                <xs:attribute name="responseDuration" use="required" type="xs:unsignedInt" />
+                                <xs:attribute name="mimeType" use="required">
+                                    <xs:simpleType>
+                                        <xs:restriction base="xs:token">
+                                            <xs:enumeration value="text/plain"/>
+                                            <xs:enumeration value="text/xml"/>
+                                            <xs:enumeration value="text/html"/>
+                                            <xs:enumeration value="audio/ogg"/>
+                                        </xs:restriction>
+                                    </xs:simpleType>
+                                </xs:attribute>
+                                <xs:attribute name="clientId"/>
+                                <xs:attribute name="strand"/>
+                                <xs:attribute name="contentLevel"/>
+                                <xs:attribute name="pageNumber" use="required" type="xs:unsignedInt"/>
+                                <xs:attribute name="pageVisits" use="required" type="xs:unsignedInt"/>
+                                <!-- this should really be unsignedInt, but there are rare occassions
+                                                  where it cannot be calculated correctly and we get a negative value.  -->
+                                <xs:attribute name="pageTime" use="required" type="xs:int"/>
+                                <xs:attribute name="dropped" use="required" type="Bit"/>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                    <xs:attribute name="server"/>
+                    <xs:attribute name="database"/>
+                    <xs:attribute name="clientName" use="required"/>
+                    <xs:attribute name="key" use="required"/>
+                    <xs:attribute name="oppId"/>
+                    <!-- note: DTD says required, but may get invalidation for joined, not-started test -->
+                    <xs:attribute name="startDate" type="NullableDateTime" use="required"/>
+                    <xs:attribute name="status" use="required">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:token">
+                                <xs:enumeration value="appeal"/>
+                                <xs:enumeration value="completed"/>
+                                <xs:enumeration value="expired"/>
+                                <xs:enumeration value="handscoring"/>
+                                <xs:enumeration value="invalidated"/>
+                                <xs:enumeration value="paused"/>
+                                <xs:enumeration value="reported"/>
+                                <xs:enumeration value="reset"/>
+                                <xs:enumeration value="scored"/>
+                                <xs:enumeration value="submitted"/>
+                                <xs:enumeration value="pending"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:attribute>
+                    <xs:attribute name="validity" use="required">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:token">
+                                <xs:enumeration value="valid"/>
+                                <xs:enumeration value="invalid"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:attribute>
+                    <xs:attribute name="completeness" use="required">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:token">
+                                <xs:enumeration value="none"/>
+                                <xs:enumeration value="partial"/>
+                                <xs:enumeration value="complete"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:attribute>
+                    <xs:attribute name="opportunity" use="required" type="xs:unsignedInt"/>
+                    <xs:attribute name="statusDate" use="required" type="xs:dateTime"/>
+                    <xs:attribute name="dateCompleted" type="NullableDateTime" use="required"/>
+                    <xs:attribute name="pauseCount" use="required" type="xs:unsignedInt"/>
+                    <xs:attribute name="itemCount" use="required" type="xs:unsignedInt"/>
+                    <xs:attribute name="ftCount" use="required" type="xs:unsignedInt"/>
+                    <xs:attribute name="abnormalStarts" use="required" type="xs:unsignedInt"/>
+                    <xs:attribute name="gracePeriodRestarts" use="required" type="xs:unsignedInt"/>
+                    <xs:attribute name="taId"/>
+                    <xs:attribute name="taName"/>
+                    <xs:attribute name="sessionId"/>
+                    <xs:attribute name="windowId" use="required"/>
+                    <xs:attribute name="windowOpportunity" type="NullableUInt"/>
+                    <xs:attribute name="completeStatus"/>
+                    <xs:attribute name="administrationCondition"/>
+                    <xs:attribute name="dateForceCompleted" type="NullableDateTime"/>
+                    <xs:attribute name="qaLevel"/>
+                    <!-- new field requested for open source -->
+                    <xs:attribute name="assessmentParticipantSessionPlatformUserAgent" use="required"/>
+                    <!-- the first date of the first window for a given assessment.  Format = YYYY-MM-DD -->
+                    <xs:attribute name="effectiveDate" use="required"/>
+                    <xs:attribute name="reportingVersion" type="xs:unsignedInt"/>
+                    <xs:attribute name="testReason"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Comment" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType mixed="true">
+                    <!-- TODO: domain values; I've seen GlobalNotes and TESTITEM, but I'm not sure how rigid this is. -->
+                    <xs:attribute name="context" use="required"/>
+                    <xs:attribute name="itemPosition" type="NullableUInt" use="required"/>
+                    <xs:attribute name="date" use="required" type="xs:dateTime"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="ToolUsage" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="ToolPage" minOccurs="1" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:attribute name="page" use="required" type="xs:unsignedInt"/>
+                                <xs:attribute name="groupId" use="required"/>
+                                <xs:attribute name="count" use="required" type="xs:unsignedInt"/>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                    <xs:attribute name="type" use="required"/>
+                    <xs:attribute name="code" use="required"/>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+</xs:element>
+<!-- recursive node requires global type so that it can be named -->
+<xs:complexType name="ScoreInfoType">
+    <xs:sequence>
+        <xs:element name="ScoreRationale" minOccurs="0" maxOccurs="1">
+            <xs:complexType mixed="true">
+                <xs:sequence>
+                    <xs:element minOccurs="0" maxOccurs="1" name="Message"/>
+                </xs:sequence>
+            </xs:complexType>
+        </xs:element>
+        <xs:element name="SubScoreList" minOccurs="0" maxOccurs="1">
+            <xs:complexType>
+                <xs:sequence>
+                    <xs:element minOccurs="0" maxOccurs="unbounded" name="ScoreInfo" type="ScoreInfoType"/>
+                </xs:sequence>
+            </xs:complexType>
+        </xs:element>
+    </xs:sequence>
+    <!-- same constaints as item/@score -->
+    <xs:attribute name="scorePoint" type="UFloatAllowNegativeOne" use="required"/>
+    <xs:attribute name="maxScore" type="UFloatAllowNegativeOne" use="required"/>
+    <!-- top level will always be "overall" (if not null); this represents the item score.  Nested ScoreInfo nodes will have dimention level scores
+        if applicable, so this will be the dimension name.  An additional level of nesting may be used for hand-scoring reads. -->
+    <xs:attribute name="scoreDimension" use="required"/>
+    <xs:attribute name="scoreStatus" use="required">
+        <xs:simpleType>
+            <xs:restriction base="xs:token">
+                <xs:enumeration value="Scored"/>
+                <xs:enumeration value="NotScored"/>
+                <xs:enumeration value="WaitingForMachineScore"/>
+                <xs:enumeration value="ScoringError"/>
+            </xs:restriction>
+        </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="conditionCode">
+        <xs:simpleType>
+            <!-- CC is 1 cap char -->
+            <xs:restriction base="xs:string">
+                <xs:maxLength value="1"/>
+                <xs:pattern value="[A-Z]"/>
+            </xs:restriction>
+        </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="sequence" type="UIntOneBased"/>
+</xs:complexType>
+<!-- some reusable types -->
+<xs:simpleType name="Bit">
+    <xs:restriction base="xs:unsignedByte">
+        <xs:minInclusive value="0"/>
+        <xs:maxInclusive value="1"/>
+    </xs:restriction>
+</xs:simpleType>
+<xs:simpleType name="Empty">
+    <xs:restriction base="xs:string">
+        <xs:enumeration value=""/>
+    </xs:restriction>
+</xs:simpleType>
+<xs:simpleType name="NegativeOne">
+    <xs:restriction base="xs:string">
+        <xs:enumeration value="-1"/>
+    </xs:restriction>
+</xs:simpleType>
+<xs:simpleType name="NullableDateTime">
+    <xs:union memberTypes="xs:dateTime Empty  ">
+    </xs:union>
+</xs:simpleType>
+<xs:simpleType name="NullableUInt">
+    <xs:union memberTypes="xs:unsignedInt Empty  ">
+    </xs:union>
+</xs:simpleType>
+<xs:simpleType name="NullableFloat">
+    <xs:union memberTypes="xs:float Empty  ">
+    </xs:union>
+</xs:simpleType>
+<xs:simpleType name="Context">
+    <xs:restriction base="xs:token">
+        <xs:enumeration value="INITIAL"/>
+        <xs:enumeration value="FINAL"/>
+    </xs:restriction>
+</xs:simpleType>
+<xs:simpleType name="UFloat">
+    <xs:restriction base="xs:float">
+        <xs:minInclusive value="0"/>
+    </xs:restriction>
+</xs:simpleType>
+<xs:simpleType name="UFloatAllowNegativeOne">
+    <xs:union memberTypes="UFloat NegativeOne  ">
+    </xs:union>
+</xs:simpleType>
+<xs:simpleType name="UIntOneBased">
+    <xs:restriction base="xs:int">
+        <xs:minInclusive value="1"/>
+    </xs:restriction>
+</xs:simpleType>
+</xs:schema>

--- a/src/test/java/tds/exam/results/mappers/CommentMapperTest.java
+++ b/src/test/java/tds/exam/results/mappers/CommentMapperTest.java
@@ -1,0 +1,55 @@
+package tds.exam.results.mappers;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import tds.exam.Exam;
+import tds.exam.ExamineeNote;
+import tds.exam.ExpandableExam;
+import tds.exam.results.trt.TDSReport;
+
+import static io.github.benas.randombeans.api.EnhancedRandom.random;
+import static io.github.benas.randombeans.api.EnhancedRandom.randomListOf;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CommentMapperTest {
+
+    @Test
+    public void shouldMapExamineeNotesToComments() {
+        ExpandableExam expandableExam = new ExpandableExam.Builder(random(Exam.class))
+            .withExamineeNotes(randomListOf(2, ExamineeNote.class))
+            .build();
+        List<TDSReport.Comment> comments = new ArrayList<>();
+
+        CommentMapper.mapComments(comments, expandableExam);
+
+        assertThat(comments.size()).isEqualTo(expandableExam.getExamineeNotes().size());
+
+        ExamineeNote examineeNote1 = expandableExam.getExamineeNotes().get(0);
+        ExamineeNote examineeNote2 = expandableExam.getExamineeNotes().get(1);
+
+        TDSReport.Comment comment1 = null;
+        TDSReport.Comment comment2 = null;
+
+        for (TDSReport.Comment comment : comments) {
+            if (Integer.parseInt(comment.getItemPosition()) == examineeNote1.getItemPosition()) {
+                comment1 = comment;
+            } else if (Integer.parseInt(comment.getItemPosition()) == examineeNote2.getItemPosition()) {
+                comment2 = comment;
+            }
+        }
+
+        assertThat(comment1.getContent()).isEqualTo(examineeNote1.getNote());
+        assertThat(comment1.getContext()).isEqualTo(examineeNote1.getContext().toString());
+        assertThat(comment1.getDate()).isNotNull();
+
+        assertThat(comment2.getContent()).isEqualTo(examineeNote2.getNote());
+        assertThat(comment2.getContext()).isEqualTo(examineeNote2.getContext().toString());
+        assertThat(comment2.getDate()).isNotNull();
+    }
+}

--- a/src/test/java/tds/exam/results/mappers/CommentMapperTest.java
+++ b/src/test/java/tds/exam/results/mappers/CommentMapperTest.java
@@ -1,8 +1,6 @@
 package tds.exam.results.mappers;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,7 +14,6 @@ import static io.github.benas.randombeans.api.EnhancedRandom.random;
 import static io.github.benas.randombeans.api.EnhancedRandom.randomListOf;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(MockitoJUnitRunner.class)
 public class CommentMapperTest {
 
     @Test

--- a/src/test/java/tds/exam/results/mappers/ExamineeMapperTest.java
+++ b/src/test/java/tds/exam/results/mappers/ExamineeMapperTest.java
@@ -1,15 +1,9 @@
 package tds.exam.results.mappers;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import tds.exam.Exam;
 import tds.exam.ExamineeAttribute;
-import tds.exam.ExamineeNote;
 import tds.exam.ExamineeRelationship;
 import tds.exam.ExpandableExam;
 import tds.exam.results.trt.Context;
@@ -19,7 +13,6 @@ import static io.github.benas.randombeans.api.EnhancedRandom.random;
 import static io.github.benas.randombeans.api.EnhancedRandom.randomListOf;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(MockitoJUnitRunner.class)
 public class ExamineeMapperTest {
 
     @Test

--- a/src/test/java/tds/exam/results/mappers/ExamineeMapperTest.java
+++ b/src/test/java/tds/exam/results/mappers/ExamineeMapperTest.java
@@ -1,0 +1,61 @@
+package tds.exam.results.mappers;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import tds.exam.Exam;
+import tds.exam.ExamineeAttribute;
+import tds.exam.ExamineeNote;
+import tds.exam.ExamineeRelationship;
+import tds.exam.ExpandableExam;
+import tds.exam.results.trt.Context;
+import tds.exam.results.trt.TDSReport;
+
+import static io.github.benas.randombeans.api.EnhancedRandom.random;
+import static io.github.benas.randombeans.api.EnhancedRandom.randomListOf;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ExamineeMapperTest {
+
+    @Test
+    public void shouldMapExamineeData() {
+        ExpandableExam expandableExam = new ExpandableExam.Builder(random(Exam.class))
+            .withExamineeAttributes(randomListOf(2, ExamineeAttribute.class))
+            .withExamineeRelationship(randomListOf(2, ExamineeRelationship.class))
+            .build();
+
+        TDSReport.Examinee examinee = ExamineeMapper.mapExaminee(expandableExam);
+
+        assertThat(examinee.getExamineeAttributeOrExamineeRelationship().size())
+            .isEqualTo(expandableExam.getExamineeRelationships().size() + expandableExam.getExamineeAttributes().size());
+
+        ExamineeAttribute examineeAttribute = expandableExam.getExamineeAttributes().get(0);
+        ExamineeRelationship examineeRelationship = expandableExam.getExamineeRelationships().get(0);
+
+        TDSReport.Examinee.ExamineeAttribute attribute1 = null;
+        TDSReport.Examinee.ExamineeRelationship relationship1 = null;
+
+        for (Object relationshipOrAttribute : examinee.getExamineeAttributeOrExamineeRelationship()) {
+            if (relationshipOrAttribute instanceof TDSReport.Examinee.ExamineeRelationship
+                && ((TDSReport.Examinee.ExamineeRelationship) relationshipOrAttribute).getName().equals(examineeRelationship.getName())) {
+                relationship1 = (TDSReport.Examinee.ExamineeRelationship) relationshipOrAttribute;
+            } else if (relationshipOrAttribute instanceof TDSReport.Examinee.ExamineeAttribute
+                && ((TDSReport.Examinee.ExamineeAttribute) relationshipOrAttribute).getName().equals(examineeAttribute.getName())) {
+                attribute1 = (TDSReport.Examinee.ExamineeAttribute) relationshipOrAttribute;
+            }
+        }
+
+        assertThat(attribute1.getValue()).isEqualTo(examineeAttribute.getValue());
+        assertThat(attribute1.getContext()).isEqualTo(Context.fromValue(examineeAttribute.getContext().name()));
+        assertThat(attribute1.getContextDate()).isNotNull();
+
+        assertThat(relationship1.getValue()).isEqualTo(examineeRelationship.getValue());
+        assertThat(relationship1.getContext()).isEqualTo(Context.fromValue(examineeRelationship.getContext().name()));
+        assertThat(relationship1.getContextDate()).isNotNull();
+    }
+}

--- a/src/test/java/tds/exam/results/mappers/OpportunityMapperTest.java
+++ b/src/test/java/tds/exam/results/mappers/OpportunityMapperTest.java
@@ -1,0 +1,132 @@
+package tds.exam.results.mappers;
+
+import org.joda.time.Instant;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import tds.assessment.Assessment;
+import tds.assessment.Item;
+import tds.exam.Exam;
+import tds.exam.ExamAccommodation;
+import tds.exam.ExamItem;
+import tds.exam.ExamItemResponse;
+import tds.exam.ExamPage;
+import tds.exam.ExamSegment;
+import tds.exam.ExpandableExam;
+import tds.exam.results.trt.TDSReport;
+import tds.session.Session;
+
+import static io.github.benas.randombeans.api.EnhancedRandom.random;
+import static io.github.benas.randombeans.api.EnhancedRandom.randomListOf;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(MockitoJUnitRunner.class)
+public class OpportunityMapperTest {
+    @Test
+    public void shouldMapExpandableExamToOpportunity() {
+        Session session = random(Session.class);
+        Assessment assessment = random(Assessment.class);
+        Exam exam = random(Exam.class);
+        List<ExamPage> examPages = randomListOf(5, ExamPage.class);
+        List<ExamAccommodation> examAccommodations = randomListOf(20, ExamAccommodation.class);
+        List<ExamSegment> examSegments = randomListOf(2, ExamSegment.class);
+        List<ExamItem> examItems = new ArrayList<>();
+
+        mapMockExamPagesAndItems(examPages, examItems);
+
+        ExpandableExam expandableExam = new ExpandableExam.Builder(exam)
+            .withExamItems(examItems)
+            .withExamPages(examPages)
+            .withExamAccommodations(examAccommodations)
+            .withExamSegments(examSegments)
+            .withStartedAt(Instant.now().minus(2000))
+            .withCompletedAt(Instant.now().minus(500))
+            .build();
+
+        List<Item> assessmentItems = expandableExam.getExamItems().stream()
+            .map(examItem -> new Item(examItem.getItemKey()))
+            .collect(Collectors.toList());
+        assessment.getSegments().forEach(segment -> segment.setItems(assessmentItems));
+
+        TDSReport.Opportunity opportunity = OpportunityMapper.mapOpportunity(expandableExam, session, assessment);
+
+        assertThat(opportunity).isNotNull();
+        assertThat(opportunity.getKey()).isEqualTo(exam.getId().toString());
+        assertThat(opportunity.getDatabase()).isEqualTo("exam");
+        assertThat(opportunity.getStartDate()).isEqualTo(exam.getStartedAt().toString());
+        assertThat(opportunity.getStatus()).isEqualTo(exam.getStatus().getCode());
+        assertThat(opportunity.getStatusDate()).isNotNull();
+        assertThat(opportunity.getDateCompleted()).isEqualTo(exam.getCompletedAt().toString());
+        assertThat(opportunity.getPauseCount()).isEqualTo(exam.getRestartsAndResumptions());
+        assertThat(opportunity.getItemCount()).isEqualTo(expandableExam.getExamItems().size());
+        assertThat(opportunity.getFtCount()).isEqualTo(expandableExam.getExamItems().stream()
+            .filter(ExamItem::isFieldTest)
+            .count());
+        assertThat(opportunity.getAbnormalStarts()).isEqualTo(exam.getAbnormalStarts());
+        assertThat(opportunity.getGracePeriodRestarts()).isEqualTo(exam.getResumptions());
+        assertThat(opportunity.getTaName()).isEqualTo(session.getProctorName());
+        assertThat(opportunity.getTaId()).isEqualTo(session.getProctorEmail());
+        assertThat(opportunity.getSessionId()).isEqualTo(session.getId().toString());
+        assertThat(opportunity.getWindowId()).isEqualTo(exam.getAssessmentWindowId());
+        assertThat(opportunity.getAssessmentParticipantSessionPlatformUserAgent()).isEqualTo(exam.getBrowserUserAgent());
+
+        // ExamSegment assertions
+        assertThat(opportunity.getSegment().size()).isEqualTo(examSegments.size());
+        ExamSegment examSegment1 = examSegments.get(0);
+        TDSReport.Opportunity.Segment oppSeg1 = null;
+
+        for (TDSReport.Opportunity.Segment oppSeg : opportunity.getSegment()) {
+            if (oppSeg.getId().equals(examSegment1.getSegmentId())) {
+                oppSeg1 = oppSeg;
+            }
+        }
+
+        assertThat(oppSeg1.getPosition()).isEqualTo((short)examSegment1.getSegmentPosition());
+        assertThat(oppSeg1.getFormKey()).isEqualTo(examSegment1.getFormKey());
+        assertThat(oppSeg1.getFormId()).isEqualTo(examSegment1.getFormId());
+        assertThat(oppSeg1.getAlgorithm()).isEqualTo(examSegment1.getAlgorithm().getType());
+        assertThat(oppSeg1.getAlgorithmVersion()).isEqualTo("0");
+
+        // ExamAccommodation assertions
+        assertThat(opportunity.getAccommodation().size()).isEqualTo(examAccommodations.size());
+        ExamAccommodation examAccommodation1 = examAccommodations.get(0);
+        TDSReport.Opportunity.Accommodation acc1 = null;
+
+        for (TDSReport.Opportunity.Accommodation accommodation : opportunity.getAccommodation()) {
+            if (accommodation.getCode().equals(examAccommodation1.getCode())) {
+                acc1 = accommodation;
+            }
+        }
+
+        assertThat(acc1.getType()).isEqualTo(examAccommodation1.getType());
+        assertThat(acc1.getSegment()).isEqualTo(examAccommodation1.getSegmentPosition());
+        assertThat(acc1.getValue()).isEqualTo(examAccommodation1.getValue());
+    }
+
+    private void mapMockExamPagesAndItems(final List<ExamPage> examPages, final List<ExamItem> examItems) {
+        // Mock/map the exam page ids from "ExamItems" to actual ExamPages.
+        for (int i = 0; i < 5; i++) {
+            ExamPage page = examPages.get(i);
+            examPages.set(i, new ExamPage.Builder()
+                .fromExamPage(page)
+                .withId(UUID.randomUUID())
+                .build());
+
+            ExamItem examItem = new ExamItem.Builder(UUID.randomUUID())
+                .withItemKey("187-" + i)
+                .withPosition(i)
+                .withExamPageId(examPages.get(i).getId())
+                .withItemType(random(String.class))
+                .withResponse(random(ExamItemResponse.class))
+                .build();
+
+            examItems.add(examItem);
+        }
+    }
+}

--- a/src/test/java/tds/exam/results/mappers/OpportunityMapperTest.java
+++ b/src/test/java/tds/exam/results/mappers/OpportunityMapperTest.java
@@ -2,8 +2,6 @@ package tds.exam.results.mappers;
 
 import org.joda.time.Instant;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -26,7 +24,6 @@ import static io.github.benas.randombeans.api.EnhancedRandom.random;
 import static io.github.benas.randombeans.api.EnhancedRandom.randomListOf;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(MockitoJUnitRunner.class)
 public class OpportunityMapperTest {
     @Test
     public void shouldMapExpandableExamToOpportunity() {

--- a/src/test/java/tds/exam/results/mappers/TestMapperTest.java
+++ b/src/test/java/tds/exam/results/mappers/TestMapperTest.java
@@ -1,8 +1,6 @@
 package tds.exam.results.mappers;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.Arrays;
 
@@ -14,7 +12,6 @@ import tds.exam.results.trt.TDSReport;
 import static io.github.benas.randombeans.api.EnhancedRandom.random;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(MockitoJUnitRunner.class)
 public class TestMapperTest {
 
     @Test

--- a/src/test/java/tds/exam/results/mappers/TestMapperTest.java
+++ b/src/test/java/tds/exam/results/mappers/TestMapperTest.java
@@ -1,0 +1,48 @@
+package tds.exam.results.mappers;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Arrays;
+
+import tds.assessment.Assessment;
+import tds.assessment.Item;
+import tds.assessment.Segment;
+import tds.exam.results.trt.TDSReport;
+
+import static io.github.benas.randombeans.api.EnhancedRandom.random;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TestMapperTest {
+
+    @Test
+    public void shouldMapAssessmentToTDSReportTest() {
+        Assessment assessment = random(Assessment.class, "segments");
+        Segment segment = random(Segment.class);
+        // Bank key should be 187
+        segment.setItems(Arrays.asList(new Item("187-1234")));
+        assessment.setSegments(Arrays.asList(segment));
+
+        TDSReport.Test reportTest = TestMapper.mapTest(assessment);
+
+        assertThat(reportTest).isNotNull();
+        assertThat(reportTest.getBankKey()).isEqualTo(187);
+        assertThat(reportTest.getName()).isEqualTo(assessment.getKey());
+        assertThat(reportTest.getSubject()).isEqualTo(assessment.getSubject());
+        assertThat(reportTest.getTestId()).isEqualTo(assessment.getAssessmentId());
+        assertThat(reportTest.getMode()).isEqualTo("online");
+    }
+
+    @Test (expected = IllegalArgumentException.class)
+    public void shouldThrowForBeingUnableToParseMalformedBankKey() {
+        Assessment assessment = random(Assessment.class, "segments");
+        Segment segment = random(Segment.class);
+        // Bank key should be 187
+        segment.setItems(Arrays.asList(new Item("foo")));
+        assessment.setSegments(Arrays.asList(segment));
+
+        TDSReport.Test reportTest = TestMapper.mapTest(assessment);
+    }
+}

--- a/src/test/java/tds/exam/results/services/impl/AssessmentServiceImplTest.java
+++ b/src/test/java/tds/exam/results/services/impl/AssessmentServiceImplTest.java
@@ -1,0 +1,41 @@
+package tds.exam.results.services.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import tds.assessment.Assessment;
+import tds.exam.results.repositories.AssessmentRepository;
+import tds.exam.results.services.AssessmentService;
+
+import static io.github.benas.randombeans.api.EnhancedRandom.random;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AssessmentServiceImplTest {
+    private AssessmentService assessmentService;
+
+    @Mock
+    private AssessmentRepository mockAssessmentRepository;
+
+    @Before
+    public void setup() {
+        assessmentService = new AssessmentServiceImpl(mockAssessmentRepository);
+    }
+
+    @Test
+    public void shouldFetchAssessment() {
+        final String clientName = "SBAC";
+        final String assessmentKey = "Assessment-key";
+        Assessment assessment = random(Assessment.class);
+
+        when(mockAssessmentRepository.findAssessment(clientName, assessmentKey)).thenReturn(assessment);
+        Assessment retAssessment = assessmentService.findAssessment(clientName, assessmentKey);
+        verify(mockAssessmentRepository).findAssessment(clientName, assessmentKey);
+        assertThat(retAssessment).isEqualTo(assessment);
+    }
+}

--- a/src/test/java/tds/exam/results/services/impl/ExamResultsServiceImplTest.java
+++ b/src/test/java/tds/exam/results/services/impl/ExamResultsServiceImplTest.java
@@ -32,6 +32,7 @@ import tds.exam.results.services.ExamResultsService;
 import tds.exam.results.services.ExamService;
 import tds.exam.results.services.SessionService;
 import tds.exam.results.trt.TDSReport;
+import tds.exam.results.validation.TDSReportValidator;
 import tds.session.Session;
 
 import static io.github.benas.randombeans.api.EnhancedRandom.random;
@@ -53,9 +54,12 @@ public class ExamResultsServiceImplTest {
     @Mock
     SessionService mockSessionService;
 
+    @Mock
+    TDSReportValidator mockReportValidator;
+
     @Before
     public void setup() throws JAXBException {
-        examResultsService = new ExamResultsServiceImpl(mockExamService, mockSessionService, mockAssessmentService);
+        examResultsService = new ExamResultsServiceImpl(mockExamService, mockSessionService, mockAssessmentService, mockReportValidator);
     }
 
     @Test

--- a/src/test/java/tds/exam/results/services/impl/ExamResultsServiceImplTest.java
+++ b/src/test/java/tds/exam/results/services/impl/ExamResultsServiceImplTest.java
@@ -1,0 +1,132 @@
+package tds.exam.results.services.impl;
+
+import org.joda.time.Instant;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.xml.sax.SAXException;
+
+import javax.xml.bind.JAXBException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import tds.assessment.Assessment;
+import tds.assessment.Item;
+import tds.exam.Exam;
+import tds.exam.ExamAccommodation;
+import tds.exam.ExamItem;
+import tds.exam.ExamItemResponse;
+import tds.exam.ExamPage;
+import tds.exam.ExamSegment;
+import tds.exam.ExamineeAttribute;
+import tds.exam.ExamineeNote;
+import tds.exam.ExamineeRelationship;
+import tds.exam.ExpandableExam;
+import tds.exam.results.services.AssessmentService;
+import tds.exam.results.services.ExamResultsService;
+import tds.exam.results.services.ExamService;
+import tds.exam.results.services.SessionService;
+import tds.exam.results.trt.TDSReport;
+import tds.session.Session;
+
+import static io.github.benas.randombeans.api.EnhancedRandom.random;
+import static io.github.benas.randombeans.api.EnhancedRandom.randomListOf;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ExamResultsServiceImplTest {
+    private ExamResultsService examResultsService;
+
+    @Mock
+    ExamService mockExamService;
+
+    @Mock
+    AssessmentService mockAssessmentService;
+
+    @Mock
+    SessionService mockSessionService;
+
+    @Before
+    public void setup() throws JAXBException {
+        examResultsService = new ExamResultsServiceImpl(mockExamService, mockSessionService, mockAssessmentService);
+    }
+
+    @Test
+    public void shouldMapExamResultsToTDSReport() throws IOException, JAXBException, SAXException {
+        Exam exam = random(Exam.class);
+        Session session = random(Session.class);
+
+        Assessment assessment = random(Assessment.class);
+        List<ExamPage> examPages = randomListOf(10, ExamPage.class);
+        List<ExamAccommodation> examAccommodations = randomListOf(20, ExamAccommodation.class);
+        List<ExamSegment> examSegments = randomListOf(2, ExamSegment.class);
+        List<ExamineeAttribute> examineeAttributes = randomListOf(20, ExamineeAttribute.class);
+        List<ExamineeRelationship> examineeRelationships = randomListOf(5, ExamineeRelationship.class);
+        List<ExamineeNote> examineeNotes = randomListOf(3, ExamineeNote.class);
+        List<ExamItem> examItems = new ArrayList<>();
+
+        mapMockExamPagesAndItems(examPages, examItems);
+
+        ExpandableExam expandableExam = new ExpandableExam.Builder(exam)
+            .withExamItems(examItems)
+            .withExamPages(examPages)
+            .withExamAccommodations(examAccommodations)
+            .withExamSegments(examSegments)
+            .withStartedAt(Instant.now().minus(2000))
+            .withCompletedAt(Instant.now().minus(500))
+            .withExamineeAttributes(examineeAttributes)
+            .withExamineeRelationship(examineeRelationships)
+            .withExamineeNotes(examineeNotes)
+            .build();
+
+        List<Item> assessmentItems = expandableExam.getExamItems().stream()
+            .map(examItem -> new Item(examItem.getItemKey()))
+            .collect(Collectors.toList());
+        assessment.getSegments().forEach(segment -> segment.setItems(assessmentItems));
+
+        when(mockExamService.findExpandableExam(exam.getId())).thenReturn(expandableExam);
+        when(mockAssessmentService.findAssessment(exam.getClientName(), exam.getAssessmentKey())).thenReturn(assessment);
+        when(mockSessionService.findSessionById(exam.getSessionId())).thenReturn(session);
+
+        TDSReport report = examResultsService.findExamResults(expandableExam.getExam().getId());
+
+        verify(mockExamService).findExpandableExam(exam.getId());
+        verify(mockAssessmentService).findAssessment(exam.getClientName(), exam.getAssessmentKey());
+        verify(mockSessionService).findSessionById(exam.getSessionId());
+
+        // NOTE: Actual mapping logic unit test coverage will be in each individual Mapper class
+        assertThat(report).isNotNull();
+        assertThat(report.getTest()).isNotNull();
+        assertThat(report.getComment()).isNotNull();
+        assertThat(report.getExaminee()).isNotNull();
+        assertThat(report.getOpportunity()).isNotNull();
+    }
+
+    private void mapMockExamPagesAndItems(final List<ExamPage> examPages, final List<ExamItem> examItems) {
+        // Mock/map the exam page ids from "ExamItems" to actual ExamPages.
+        for (int i = 0; i < 10; i++) {
+            ExamPage page = examPages.get(i);
+            examPages.set(i, new ExamPage.Builder()
+                .fromExamPage(page)
+                .withId(UUID.randomUUID())
+                .build());
+
+            ExamItem examItem = new ExamItem.Builder(UUID.randomUUID())
+                .withItemKey("187-" + i)
+                .withPosition(i)
+                .withExamPageId(examPages.get(i).getId())
+                .withItemType(random(String.class))
+                .withResponse(random(ExamItemResponse.class))
+                .build();
+
+            examItems.add(examItem);
+        }
+    }
+}

--- a/src/test/java/tds/exam/results/services/impl/ExamServiceImplTest.java
+++ b/src/test/java/tds/exam/results/services/impl/ExamServiceImplTest.java
@@ -1,0 +1,40 @@
+package tds.exam.results.services.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import tds.exam.ExpandableExam;
+import tds.exam.results.repositories.ExamRepository;
+import tds.exam.results.services.ExamService;
+
+import static io.github.benas.randombeans.api.EnhancedRandom.random;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ExamServiceImplTest {
+    private ExamService examService;
+
+    @Mock
+    private ExamRepository mockExamRepository;
+
+    @Before
+    public void setup() {
+        this.examService = new ExamServiceImpl(mockExamRepository);
+    }
+
+    @Test
+    public void shouldFindExam() {
+        ExpandableExam expandableExam = random(ExpandableExam.class);
+
+        when(mockExamRepository.findExpandableExam(expandableExam.getExam().getId())).thenReturn(expandableExam);
+        ExpandableExam retExpandableExam = examService.findExpandableExam(expandableExam.getExam().getId());
+        verify(mockExamRepository).findExpandableExam(expandableExam.getExam().getId());
+
+        assertThat(retExpandableExam).isEqualTo(expandableExam);
+    }
+}

--- a/src/test/java/tds/exam/results/services/impl/SessionServiceImplTest.java
+++ b/src/test/java/tds/exam/results/services/impl/SessionServiceImplTest.java
@@ -1,0 +1,43 @@
+package tds.exam.results.services.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.UUID;
+
+import tds.exam.results.repositories.SessionRepository;
+import tds.exam.results.services.SessionService;
+import tds.session.Session;
+
+import static io.github.benas.randombeans.api.EnhancedRandom.random;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SessionServiceImplTest {
+    private SessionService sessionService;
+
+    @Mock
+    private SessionRepository mockSessionRepository;
+
+    @Before
+    public void setup() {
+        sessionService = new SessionServiceImpl(mockSessionRepository);
+    }
+
+    @Test
+    public void shouldFindSession() {
+        UUID sessionId = UUID.randomUUID();
+        Session session = random(Session.class);
+
+        when(mockSessionRepository.findSessionById(sessionId)).thenReturn(session);
+        Session retSession = sessionService.findSessionById(sessionId);
+        verify(mockSessionRepository).findSessionById(sessionId);
+
+        assertThat(retSession).isEqualTo(session);
+    }
+}


### PR DESCRIPTION
This PR contains code that will handle the mapping of our performance Assessment, (Expandable)Exam, and Session objects to a TDSReport jaxb object representing the TRT. This PR does not contain any logic pertaining to persisting the TRT XML blob in any database, nor does it contain anything messaging-related.

A few notes:
- There are quite a few TODOs when it comes to exam item/responses/scores, as well as some assessment data that we are lacking
- There is no controller test coverage for the time being - this is because the only endpoint that exists is simply for developmental purposes and will be disabled in production.
- OpportunityMapper test is missing some item/response assertions - this is because most of that mapping logic is yet to be implemented.