### PR TITLE
Allow reading XSD from classpath

### DIFF
--- a/src/main/java/tds/exam/results/validation/impl/XSDBackedTDSReportValidator.java
+++ b/src/main/java/tds/exam/results/validation/impl/XSDBackedTDSReportValidator.java
@@ -9,10 +9,12 @@ import javax.xml.XMLConstants;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.util.JAXBSource;
+import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Validator;
 import java.io.IOException;
+import java.io.InputStream;
 
 import tds.exam.results.configuration.ExamResultsTransmitterServiceProperties;
 import tds.exam.results.trt.TDSReport;
@@ -25,13 +27,16 @@ public class XSDBackedTDSReportValidator implements TDSReportValidator {
     private final ExamResultsTransmitterServiceProperties properties;
 
     XSDBackedTDSReportValidator(final JAXBContext jaxbContext,
-                                @Value("classpath:xsd/TestResultsTransmissionFormat_Schema.xsd") final Resource xsd,
+                                @Value("classpath:/xsd/TestResultsTransmissionFormat_Schema.xsd") final Resource xsd,
                                 final ExamResultsTransmitterServiceProperties properties) throws IOException, SAXException {
         this.jaxbContext = jaxbContext;
         this.properties = properties;
-        SchemaFactory sf = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
-        Schema schema = sf.newSchema(xsd.getFile());
-        validator = schema.newValidator();
+        final SchemaFactory sf = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+
+        try (final InputStream xsdStream = xsd.getInputStream()) {
+            final Schema schema = sf.newSchema(new StreamSource(xsdStream));
+            validator = schema.newValidator();
+        }
     }
 
     @Override


### PR DESCRIPTION

When running the service in a docker container, I was getting IOExceptions when attempting to read the XSD file due to attempting to access the Resource as a File.  
Per the Resource#getFile() javadoc:
```
	/**
	 * Return a File handle for this resource.
	 * @throws IOException if the resource cannot be resolved as absolute
	 * file path, i.e. if the resource is not available in a file system
	 */
	File getFile() throws IOException;
```

We should keep this in mind when working with Resource objects in the future.