### PR TITLE
Defaulting academic year to “0” when no academic year is set in the i…

### DIFF
--- a/src/main/java/tds/exam/results/mappers/TestMapper.java
+++ b/src/main/java/tds/exam/results/mappers/TestMapper.java
@@ -2,6 +2,8 @@ package tds.exam.results.mappers;
 
 
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -13,6 +15,7 @@ import tds.exam.results.trt.TDSReport;
  * A class used for mapping a {@link tds.exam.results.trt.TDSReport.Test} object from {@link tds.assessment.Assessment} data
  */
 public class TestMapper {
+    private final static Logger log = LoggerFactory.getLogger(TestMapper.class);
     private final static String TEST_MODE_ONLINE = "online";
     private static final String HIGH_SCHOOL_GRADE_STRING = "HS";
     private static final int MIN_HIGH_SCHOOL_GRADE = 9;
@@ -37,7 +40,7 @@ public class TestMapper {
         test.setMode(TEST_MODE_ONLINE);
         test.setGrade(createGradeStringFromGrades(assessment.getGrades()));
         test.setAssessmentType(assessment.getType());
-        test.setAcademicYear(parseLatestAcademicYear(assessment.getAcademicYear()));
+        test.setAcademicYear(parseLatestAcademicYear(assessment.getAcademicYear(), assessment.getKey()));
         test.setAssessmentVersion(assessment.getUpdateVersion() == null
             ? String.valueOf(assessment.getLoadVersion())
             : String.valueOf(assessment.getUpdateVersion()));
@@ -54,9 +57,15 @@ public class TestMapper {
     }
 
     /* Rule: If a date range, select the latest year */
-    private static long parseLatestAcademicYear(final String academicYearString) {
+    private static long parseLatestAcademicYear(final String academicYearString, final String key) {
+        if (academicYearString.equals("")) {
+            // If the configs.tbltestadmin table is not configured with an academic year, set this value to 0
+            log.error("The academic year for the assessment was not set in the configuration database for assessment {}. Defaulting to '0'.",
+                key);
+            return 0;
+        }
         // If this is a range date, pick the latest year
-        if (academicYearString.contains("-")) {
+        else if (academicYearString.contains("-")) {
             return Long.parseLong(academicYearString.split("-")[1]);
         }
 

--- a/src/test/java/tds/exam/results/mappers/TestMapperTest.java
+++ b/src/test/java/tds/exam/results/mappers/TestMapperTest.java
@@ -43,6 +43,25 @@ public class TestMapperTest {
     }
 
     @Test
+    public void shouldMapAssessmentToTDSReportTestWithBlankAcademicYear() {
+        Assessment assessment = random(Assessment.class, "segments");
+        Segment segment = random(Segment.class);
+        // Bank key should be 187
+        segment.setItems(Arrays.asList(new Item("187-1234")));
+        assessment.setSegments(Arrays.asList(segment));
+
+        assessment.setGrades(Collections.singletonList("8"));
+        assessment.setAcademicYear("");
+        assessment.setLoadVersion(1234L);
+        assessment.setUpdateVersion(4321L);
+
+        TDSReport.Test reportTest = TestMapper.mapTest(assessment);
+
+        assertThat(reportTest).isNotNull();
+        assertThat(reportTest.getAcademicYear()).isEqualTo(0L);
+    }
+
+    @Test
     public void shouldMapAssessmentToTDSReportTestWithGradeRangeAndNoUpdateVersion() {
         Assessment assessment = random(Assessment.class, "segments");
         Segment segment = random(Segment.class);


### PR DESCRIPTION
…tembank.tbltestadmin - which is manually set.

https://jira.fairwaytech.com/browse/TDS-890

Some notes:

- I'm not the biggest fan of sending 0 or -1, but because this value is defined as an unsigned-int in the XSD (a java "long") and because it is a required field, we cannot feed it a non-numerical value. 
- This field is, according to @jtreuting set manually as part of TDS configuration. Unfortunately, it is also nullable. We never saw this issue in QA or any of our dev environments because they all had academic years assigned in `itembank.tbltestadmin`. Our loadtest environment, however, does not.