### PR TITLE
ERT will call exam status update endpoint when it receives the ERT me…

### DIFF
--- a/src/main/java/tds/exam/results/messaging/ExamCompletedMessageListener.java
+++ b/src/main/java/tds/exam/results/messaging/ExamCompletedMessageListener.java
@@ -5,7 +5,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import tds.exam.ExamStatusCode;
 import tds.exam.results.services.ExamResultsService;
+import tds.exam.results.services.ExamService;
 import tds.exam.results.trt.TDSReport;
 
 import java.util.UUID;
@@ -19,9 +21,13 @@ public class ExamCompletedMessageListener {
 
     private final ExamResultsService examResultsService;
 
+    private final ExamService examService;
+
     @Autowired
-    public ExamCompletedMessageListener(final ExamResultsService examResultsService) {
+    public ExamCompletedMessageListener(final ExamResultsService examResultsService,
+                                        final ExamService examService) {
         this.examResultsService = examResultsService;
+        this.examService = examService;
     }
 
     /**
@@ -36,6 +42,9 @@ public class ExamCompletedMessageListener {
      */
     public void handleMessage(final String examId) {
         LOG.debug("Received completed exam notification for id: {}", examId);
-        examResultsService.findAndSendExamResults(UUID.fromString(examId));
+        // Once this ERT message has been received, the exam status is "submitted"
+        UUID id = UUID.fromString(examId);
+        examService.updateStatus(id, ExamStatusCode.STATUS_SUBMITTED);
+        examResultsService.findAndSendExamResults(id);
     }
 }

--- a/src/main/java/tds/exam/results/repositories/ExamRepository.java
+++ b/src/main/java/tds/exam/results/repositories/ExamRepository.java
@@ -1,7 +1,10 @@
 package tds.exam.results.repositories;
 
+import com.google.common.base.Optional;
+
 import java.util.UUID;
 
+import tds.common.ValidationError;
 import tds.exam.ExpandableExam;
 
 /**
@@ -15,4 +18,12 @@ public interface ExamRepository {
      * @return The fully populated {@link tds.exam.ExpandableExam}
      */
     ExpandableExam findExpandableExam(final UUID examId);
+
+    /**
+     * Creates a request to update the status of an exam
+     *
+     * @param examId the id of the {@link tds.exam.Exam}
+     * @param status the status to update the exam to
+     */
+    void updateStatus(final UUID examId, final String status);
 }

--- a/src/main/java/tds/exam/results/repositories/impl/RemoteExamRepository.java
+++ b/src/main/java/tds/exam/results/repositories/impl/RemoteExamRepository.java
@@ -13,6 +13,9 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.UUID;
 
+import tds.common.web.resources.NoContentResponseResource;
+import tds.exam.ExamStatusCode;
+import tds.exam.ExamStatusRequest;
 import tds.exam.ExpandableExam;
 import tds.exam.ExpandableExamAttributes;
 import tds.exam.results.configuration.ExamResultsTransmitterServiceProperties;
@@ -59,5 +62,25 @@ public class RemoteExamRepository implements ExamRepository {
             });
 
         return responseEntity.getBody();
+    }
+
+    @Override
+    public void updateStatus(final UUID examId, final String status) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Accept", MediaType.APPLICATION_JSON_VALUE);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        ExamStatusRequest request = new ExamStatusRequest(new ExamStatusCode(status), "ExamResultsTransmitter");
+
+        HttpEntity<?> requestHttpEntity = new HttpEntity<>(request, headers);
+
+        UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(String.format("%s/%s/%s/status",
+          properties.getExamUrl(), EXAM_APP_CONTEXT, examId));
+
+        restTemplate.exchange(
+          builder.build().toUri(),
+          HttpMethod.PUT,
+          requestHttpEntity,
+          new ParameterizedTypeReference<NoContentResponseResource>() {
+          });
     }
 }

--- a/src/main/java/tds/exam/results/services/ExamService.java
+++ b/src/main/java/tds/exam/results/services/ExamService.java
@@ -15,4 +15,12 @@ public interface ExamService {
      * @return The fully-populated {@link tds.exam.ExpandableExam}
      */
     ExpandableExam findExpandableExam(final UUID examId);
+
+    /**
+     * Updates the status of an exam
+     *
+     * @param examId the id of the {@link tds.exam.Exam}
+     * @param status the status to update the exam to
+     */
+    void updateStatus(final UUID examId, final String status);
 }

--- a/src/main/java/tds/exam/results/services/impl/ExamServiceImpl.java
+++ b/src/main/java/tds/exam/results/services/impl/ExamServiceImpl.java
@@ -22,4 +22,9 @@ public class ExamServiceImpl implements ExamService {
     public ExpandableExam findExpandableExam(final UUID examId) {
         return examRepository.findExpandableExam(examId);
     }
+
+    @Override
+    public void updateStatus(final UUID examId, final String status) {
+        examRepository.updateStatus(examId, status);
+    }
 }

--- a/src/test/java/tds/exam/results/messaging/ExamCompletedMessageListenerTest.java
+++ b/src/test/java/tds/exam/results/messaging/ExamCompletedMessageListenerTest.java
@@ -9,7 +9,9 @@ import org.mockito.runners.MockitoJUnitRunner;
 import javax.xml.bind.JAXBException;
 import java.util.UUID;
 
+import tds.exam.ExamStatusCode;
 import tds.exam.results.services.ExamResultsService;
+import tds.exam.results.services.ExamService;
 
 import static org.mockito.Mockito.verify;
 
@@ -19,17 +21,21 @@ public class ExamCompletedMessageListenerTest {
     @Mock
     private ExamResultsService mockExamResultsService;
 
+    @Mock
+    private ExamService mockExamService;
+
     private ExamCompletedMessageListener listener;
 
     @Before
     public void setup() {
-        listener = new ExamCompletedMessageListener(mockExamResultsService);
+        listener = new ExamCompletedMessageListener(mockExamResultsService, mockExamService);
     }
 
     @Test
     public void itShouldGenerateAReportForTheExamId() throws JAXBException {
         final UUID examId = UUID.randomUUID();
         listener.handleMessage(examId.toString());
+        verify(mockExamService).updateStatus(examId, ExamStatusCode.STATUS_SUBMITTED);
         verify(mockExamResultsService).findAndSendExamResults(examId);
     }
 }

--- a/src/test/java/tds/exam/results/services/impl/ExamServiceImplTest.java
+++ b/src/test/java/tds/exam/results/services/impl/ExamServiceImplTest.java
@@ -6,6 +6,9 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import java.util.UUID;
+
+import tds.exam.ExamStatusCode;
 import tds.exam.ExpandableExam;
 import tds.exam.results.repositories.ExamRepository;
 import tds.exam.results.services.ExamService;
@@ -36,5 +39,12 @@ public class ExamServiceImplTest {
         verify(mockExamRepository).findExpandableExam(expandableExam.getExam().getId());
 
         assertThat(retExpandableExam).isEqualTo(expandableExam);
+    }
+
+    @Test
+    public void shouldUpdateExamStatus() {
+        UUID examId = UUID.randomUUID();
+        examService.updateStatus(examId, ExamStatusCode.STATUS_SUBMITTED);
+        verify(mockExamRepository).updateStatus(examId, ExamStatusCode.STATUS_SUBMITTED);
     }
 }


### PR DESCRIPTION
…ssage from Exam.

This is part of https://jira.fairwaytech.com/browse/TDS-537

ReportingDLL.java - Line 2170 
- In the legacy app, after the "message" is picked up off of the qareportqueue table by the SRP, the status is updated to "submitted" (before it is processed and shipped to TIS).
- In our implementation, as soon as the ERT receives the message from Exam, it will call back to the updateStatus endpoint on exam service to set the status to "submitted". After the TRT is craeted and sent to TIS, TIS will callback to ERT, which will then set the status to "reported" if TIS was successful in reporting the exam.