### PR TITLE
TDS-897: Feature/retry attempts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,12 @@
             <groupId>org.springframework.security.oauth</groupId>
             <artifactId>spring-security-oauth2</artifactId>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.springframework.amqp/spring-rabbit-test -->
+        <dependency>
+            <groupId>org.springframework.amqp</groupId>
+            <artifactId>spring-rabbit-test</artifactId>
+            <version>1.6.0.RELEASE</version>
+        </dependency>
 
         <dependency>
             <groupId>joda-time</groupId>

--- a/src/main/java/tds/exam/results/configuration/ExamResultsTransmitterServiceProperties.java
+++ b/src/main/java/tds/exam/results/configuration/ExamResultsTransmitterServiceProperties.java
@@ -14,6 +14,10 @@ public class ExamResultsTransmitterServiceProperties {
     private boolean validateTrtXml = false;
     private boolean sendToTis = false;
     private boolean retryOnError = true;
+    private long retryInitialInterval = 1000;
+    private double retryIntervalMultiplier = 2;
+    private long retryMaxInterval = 5000;
+    private int retryAmount = 3;
 
     /**
      * Get the URL for the session microservice.
@@ -122,5 +126,49 @@ public class ExamResultsTransmitterServiceProperties {
 
     public void setRetryOnError(final boolean retryOnError) {
         this.retryOnError = retryOnError;
+    }
+
+    /**
+     * @return the initial interval retry time that will be used as we graduate to larger numbers between retries
+     */
+    public long getRetryInitialInterval() {
+        return retryInitialInterval;
+    }
+
+    public void setRetryInitialInterval(final long retryInitialInterval) {
+        this.retryInitialInterval = retryInitialInterval;
+    }
+
+    /**
+     * @return the interval between retries
+     */
+    public double getRetryIntervalMultiplier() {
+        return retryIntervalMultiplier;
+    }
+
+    public void setRetryIntervalMultiplier(final double retryIntervalMultiplier) {
+        this.retryIntervalMultiplier = retryIntervalMultiplier;
+    }
+
+    /**
+     * @return the max interval the retry will scale to
+     */
+    public long getRetryMaxInterval() {
+        return retryMaxInterval;
+    }
+
+    public void setRetryMaxInterval(final long retryMaxInterval) {
+        this.retryMaxInterval = retryMaxInterval;
+    }
+
+    /**
+     * @return the number of times a message will be retried
+     */
+    public int getRetryAmount() {
+        return retryAmount;
+    }
+
+    public void setRetryAmount(final int retryAmount) {
+        this.retryAmount = retryAmount;
     }
 }

--- a/src/main/java/tds/exam/results/configuration/ExamResultsTransmitterServiceProperties.java
+++ b/src/main/java/tds/exam/results/configuration/ExamResultsTransmitterServiceProperties.java
@@ -13,7 +13,6 @@ public class ExamResultsTransmitterServiceProperties {
     private String tisCallbackUrl = "";
     private boolean validateTrtXml = false;
     private boolean sendToTis = false;
-    private boolean retryOnError = true;
     private long retryInitialInterval = 1000;
     private double retryIntervalMultiplier = 2;
     private long retryMaxInterval = 5000;
@@ -115,17 +114,6 @@ public class ExamResultsTransmitterServiceProperties {
 
     public void setSendToTis(boolean sendToTis) {
         this.sendToTis = sendToTis;
-    }
-
-    /**
-     * @return {@code true} to continuously retry on error
-     */
-    public boolean isRetryOnError() {
-        return retryOnError;
-    }
-
-    public void setRetryOnError(final boolean retryOnError) {
-        this.retryOnError = retryOnError;
     }
 
     /**

--- a/src/main/java/tds/exam/results/configuration/messaging/ExamResultsTransmitterMessageRecoverer.java
+++ b/src/main/java/tds/exam/results/configuration/messaging/ExamResultsTransmitterMessageRecoverer.java
@@ -1,0 +1,15 @@
+package tds.exam.results.configuration.messaging;
+
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.rabbit.retry.RejectAndDontRequeueRecoverer;
+
+
+public class ExamResultsTransmitterMessageRecoverer extends RejectAndDontRequeueRecoverer {
+    private static final org.slf4j.Logger log = LoggerFactory.getLogger(ExamResultsTransmitterMessageRecoverer.class);
+
+    @Override
+    public void recover(final Message message, final Throwable cause) {
+        log.warn(String.format("Could not put message to ERT completion queue. message: %s", message), cause);
+    }
+}

--- a/src/main/java/tds/exam/results/configuration/messaging/ExamResultsTransmitterMessageRecoverer.java
+++ b/src/main/java/tds/exam/results/configuration/messaging/ExamResultsTransmitterMessageRecoverer.java
@@ -4,12 +4,14 @@ import org.slf4j.LoggerFactory;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.rabbit.retry.RejectAndDontRequeueRecoverer;
 
-
+/**
+ * Handles the message after it has been rejected the required number of times.
+ */
 public class ExamResultsTransmitterMessageRecoverer extends RejectAndDontRequeueRecoverer {
     private static final org.slf4j.Logger log = LoggerFactory.getLogger(ExamResultsTransmitterMessageRecoverer.class);
 
     @Override
     public void recover(final Message message, final Throwable cause) {
-        log.warn(String.format("Could not put message to ERT completion queue. message: %s", message), cause);
+        log.error(String.format("Unable to send TRT for completed exam to TIS with message: %s", message), cause);
     }
 }

--- a/src/main/java/tds/exam/results/configuration/messaging/ExamResultsTransmitterMessagingConfiguration.java
+++ b/src/main/java/tds/exam/results/configuration/messaging/ExamResultsTransmitterMessagingConfiguration.java
@@ -4,12 +4,14 @@ import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.core.BindingBuilder;
 import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.core.TopicExchange;
+import org.springframework.amqp.rabbit.config.RetryInterceptorBuilder;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
 import org.springframework.amqp.rabbit.listener.adapter.MessageListenerAdapter;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.interceptor.RetryOperationsInterceptor;
 
 import tds.exam.results.messaging.ExamCompletedMessageListener;
 
@@ -47,5 +49,13 @@ public class ExamResultsTransmitterMessagingConfiguration {
         container.setQueueNames(QUEUE_EXAM_COMPLETION);
         container.setMessageListener(new MessageListenerAdapter(listener, "handleMessage"));
         return container;
+    }
+
+    @Bean
+    RetryOperationsInterceptor examCompletionInterceptor() {
+        return RetryInterceptorBuilder.stateless()
+            .maxAttempts(3)
+            .recoverer(new ExamResultsTransmitterMessageRecoverer())
+            .build();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -51,6 +51,10 @@ exam-results-transmitter-service:
   validate-trt-xml: false
   send-to-tis: false
   retry-on-error: false
+  retry-initial-interval: 1000
+  retry-interval-multiplier: 2
+  retry-max-interval: 5000
+  retry-amount: 3
 
 oauth:
   tis-client-id: ${oauth.tis.client.id}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -50,7 +50,6 @@ exam-results-transmitter-service:
   tis-callback-url: ${sbac.tis.callback.url}
   validate-trt-xml: false
   send-to-tis: false
-  retry-on-error: false
   retry-initial-interval: 1000
   retry-interval-multiplier: 2
   retry-max-interval: 5000

--- a/src/test/java/tds/exam/results/messaging/ExamCompletedMessageListenerTest.java
+++ b/src/test/java/tds/exam/results/messaging/ExamCompletedMessageListenerTest.java
@@ -35,7 +35,7 @@ public class ExamCompletedMessageListenerTest {
 
     @Before
     public void setup() {
-        listener = new ExamCompletedMessageListener(mockExamResultsService, mockExamService, mockProperties);
+        listener = new ExamCompletedMessageListener(mockExamResultsService, mockExamService);
     }
 
     @Test

--- a/src/test/java/tds/exam/results/messaging/ExamCompletedMessageListenerTest.java
+++ b/src/test/java/tds/exam/results/messaging/ExamCompletedMessageListenerTest.java
@@ -10,14 +10,10 @@ import javax.xml.bind.JAXBException;
 import java.util.UUID;
 
 import tds.exam.ExamStatusCode;
-import tds.exam.results.configuration.ExamResultsTransmitterServiceProperties;
 import tds.exam.results.services.ExamResultsService;
 import tds.exam.results.services.ExamService;
 
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
-import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ExamCompletedMessageListenerTest {
@@ -27,9 +23,6 @@ public class ExamCompletedMessageListenerTest {
 
     @Mock
     private ExamService mockExamService;
-
-    @Mock
-    private ExamResultsTransmitterServiceProperties mockProperties;
 
     private ExamCompletedMessageListener listener;
 

--- a/src/test/java/tds/exam/results/messaging/ExamCompletedMessageListenerTest.java
+++ b/src/test/java/tds/exam/results/messaging/ExamCompletedMessageListenerTest.java
@@ -45,29 +45,4 @@ public class ExamCompletedMessageListenerTest {
         verify(mockExamService).updateStatus(examId, ExamStatusCode.STATUS_SUBMITTED);
         verify(mockExamResultsService).findAndSendExamResults(examId);
     }
-
-    @Test(expected = IllegalStateException.class)
-    public void itShouldOptionallyRetryOnError() {
-        final UUID examId = UUID.randomUUID();
-
-        when(mockProperties.isRetryOnError()).thenReturn(true);
-        doThrow(new IllegalStateException("Badness"))
-            .when(mockExamService)
-            .updateStatus(examId, ExamStatusCode.STATUS_SUBMITTED);
-
-        listener.handleMessage(examId.toString());
-    }
-
-    @Test
-    public void itShouldOptionallyNotRetryOnError() {
-        final UUID examId = UUID.randomUUID();
-
-        when(mockProperties.isRetryOnError()).thenReturn(false);
-        doThrow(new IllegalStateException("Badness"))
-            .when(mockExamService)
-            .updateStatus(examId, ExamStatusCode.STATUS_SUBMITTED);
-
-        listener.handleMessage(examId.toString());
-        verifyZeroInteractions(mockExamResultsService);
-    }
 }

--- a/src/test/java/tds/exam/results/services/impl/MessagingServiceImplTest.java
+++ b/src/test/java/tds/exam/results/services/impl/MessagingServiceImplTest.java
@@ -78,25 +78,4 @@ public class MessagingServiceImplTest {
         messagingService.sendReportAcknowledgement(examId, tisState);
         verify(mockRabbitTemplate, never()).convertAndSend(eq(TOPIC_EXCHANGE), eq(TOPIC_EXAM_REPORTED), eq(tisState.getExamId()), isA(CorrelationData.class));
     }
-
-    @Test(expected = AmqpException.class)
-    public void shouldRetryThreeTimesThenLogFailure() {
-        final TISState tisState = new TISState.Builder()
-            .withExamId(UUID.randomUUID().toString())
-            .withSuccess(true)
-            .build();
-        final UUID examId = UUID.fromString(tisState.getExamId());
-
-        doThrow(new AmqpException("unit test exception"))
-            .when(mockRabbitTemplate).convertAndSend(eq(TOPIC_EXCHANGE),
-            eq(TOPIC_EXAM_REPORTED),
-            eq(tisState.getExamId()),
-            isA(CorrelationData.class));
-
-        messagingService.sendReportAcknowledgement(examId, tisState);
-        verify(mockRabbitTemplate, times(5)).convertAndSend(eq(TOPIC_EXCHANGE),
-            eq(TOPIC_EXAM_REPORTED),
-            eq(tisState.getExamId()),
-            isA(CorrelationData.class));
-    }
 }

--- a/src/test/java/tds/exam/results/services/impl/MessagingServiceImplTest.java
+++ b/src/test/java/tds/exam/results/services/impl/MessagingServiceImplTest.java
@@ -5,28 +5,18 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.mockito.verification.VerificationMode;
-import org.omg.CORBA.Object;
-import org.springframework.amqp.AmqpException;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.rabbit.support.CorrelationData;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.UUID;
 
 import tds.exam.results.services.MessagingService;
 import tds.exam.results.tis.TISState;
 
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isA;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
-import static org.mockito.Mockito.when;
 import static tds.exam.ExamTopics.TOPIC_EXAM_REPORTED;
 import static tds.exam.ExamTopics.TOPIC_EXCHANGE;
 

--- a/src/test/java/tds/exam/results/services/impl/MessagingServiceImplTest.java
+++ b/src/test/java/tds/exam/results/services/impl/MessagingServiceImplTest.java
@@ -5,18 +5,28 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.verification.VerificationMode;
+import org.omg.CORBA.Object;
+import org.springframework.amqp.AmqpException;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.rabbit.support.CorrelationData;
+import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.UUID;
 
 import tds.exam.results.services.MessagingService;
 import tds.exam.results.tis.TISState;
 
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
 import static tds.exam.ExamTopics.TOPIC_EXAM_REPORTED;
 import static tds.exam.ExamTopics.TOPIC_EXCHANGE;
 
@@ -67,5 +77,26 @@ public class MessagingServiceImplTest {
 
         messagingService.sendReportAcknowledgement(examId, tisState);
         verify(mockRabbitTemplate, never()).convertAndSend(eq(TOPIC_EXCHANGE), eq(TOPIC_EXAM_REPORTED), eq(tisState.getExamId()), isA(CorrelationData.class));
+    }
+
+    @Test(expected = AmqpException.class)
+    public void shouldRetryThreeTimesThenLogFailure() {
+        final TISState tisState = new TISState.Builder()
+            .withExamId(UUID.randomUUID().toString())
+            .withSuccess(true)
+            .build();
+        final UUID examId = UUID.fromString(tisState.getExamId());
+
+        doThrow(new AmqpException("unit test exception"))
+            .when(mockRabbitTemplate).convertAndSend(eq(TOPIC_EXCHANGE),
+            eq(TOPIC_EXAM_REPORTED),
+            eq(tisState.getExamId()),
+            isA(CorrelationData.class));
+
+        messagingService.sendReportAcknowledgement(examId, tisState);
+        verify(mockRabbitTemplate, times(5)).convertAndSend(eq(TOPIC_EXCHANGE),
+            eq(TOPIC_EXAM_REPORTED),
+            eq(tisState.getExamId()),
+            isA(CorrelationData.class));
     }
 }


### PR DESCRIPTION
[TDS-897](https://jira.fairwaytech.com/browse/TDS-897):
* Add a retry and recovery mechanism to the RabbitMQ container for handling messages
  * If a message cannot be processed after the specified number of retries, the message will be acknowledged, logged and discarded
* Added configuration properties to dictate the number of retries and the retry attempts
* Removed the `retryOnError`, since that behavior is now managed by the RabbitMQ configuration in this application

#### Notes
Unfortunately, creating integration tests against RabbitMQ to test the recovery mechanism would take more time than I had available for this PR.  The test of the retry mechanism was conducted manually by debugging the ERT locally and verifying the desired behavior.