### PR TITLE
Parsing strand name from contentLevel string

### DIFF
--- a/src/main/java/tds/exam/results/mappers/OpportunityMapper.java
+++ b/src/main/java/tds/exam/results/mappers/OpportunityMapper.java
@@ -131,7 +131,7 @@ public class OpportunityMapper {
             opportunityItem.setAdminDate(JaxbMapperUtils.convertInstantToGregorianCalendar(examPage.getCreatedAt()));
             opportunityItem.setNumberVisits(itemVisitsMap.get(examItem.getId()));
             opportunityItem.setMimeType(assessmentItem.getMimeType());
-            opportunityItem.setStrand(assessmentItem.getContentLevel());
+            opportunityItem.setStrand(getStrandFromContentLevel(assessmentItem.getContentLevel()));
             opportunityItem.setContentLevel(assessmentItem.getContentLevel());
             opportunityItem.setPageNumber(examPage.getPagePosition());
             opportunityItem.setPageTime((int) examPage.getDuration());
@@ -180,6 +180,14 @@ public class OpportunityMapper {
 
             opportunityItems.add(opportunityItem);
         }
+    }
+
+    private static String getStrandFromContentLevel(final String contentLevel) {
+        if (contentLevel.contains("|")) {
+            return contentLevel.split("\\|")[0];
+        }
+
+        return contentLevel;
     }
 
     private static void mapExamAccommodationsToOpportunity(final List<ExamAccommodation> examAccommodations,

--- a/src/main/java/tds/exam/results/mappers/OpportunityMapper.java
+++ b/src/main/java/tds/exam/results/mappers/OpportunityMapper.java
@@ -182,6 +182,7 @@ public class OpportunityMapper {
         }
     }
 
+    /* Port of ReportingDLL.ItemkeyStrandName_F() */
     private static String getStrandFromContentLevel(final String contentLevel) {
         if (contentLevel.contains("|")) {
             return contentLevel.split("\\|")[0];

--- a/src/test/java/tds/exam/results/mappers/OpportunityMapperTest.java
+++ b/src/test/java/tds/exam/results/mappers/OpportunityMapperTest.java
@@ -42,7 +42,11 @@ public class OpportunityMapperTest {
 
         final List<Item> assessmentItems = examSegmentWrapper.getExamPages().stream()
             .flatMap(p -> p.getExamItems().stream())
-            .map(examItem -> new Item(examItem.getItemKey()))
+            .map(examItem -> {
+                Item item = new Item(examItem.getItemKey());
+                item.setContentLevel("Strand|TL|D-R");
+                return item;
+            })
             .collect(Collectors.toList());
 
         assessment.getSegments().forEach(segment -> segment.setItems(assessmentItems));
@@ -109,6 +113,8 @@ public class OpportunityMapperTest {
             assertThat(item.getBankKey()).isEqualTo(187);
             assertThat(item.getKey()).isGreaterThan(0);
             assertThat(item.getOperational()).isEqualTo((short) 1);
+            assertThat(item.getContentLevel()).isEqualTo("Strand|TL|D-R");
+            assertThat(item.getStrand()).isEqualTo("Strand");
             TDSReport.Opportunity.Item.Response response = item.getResponse();
 
             assertThat(response).isNotNull();
@@ -128,7 +134,11 @@ public class OpportunityMapperTest {
 
         final List<Item> assessmentItems = examSegmentWrapper.getExamPages().stream()
             .flatMap(p -> p.getExamItems().stream())
-            .map(examItem -> new Item(examItem.getItemKey()))
+            .map(examItem -> {
+                Item item = new Item(examItem.getItemKey());
+                item.setContentLevel("Strand|TL|D-R");
+                return item;
+            })
             .collect(Collectors.toList());
 
         assessment.getSegments().forEach(segment -> segment.setItems(assessmentItems));
@@ -156,7 +166,11 @@ public class OpportunityMapperTest {
 
         final List<Item> assessmentItems = examSegmentWrapper.getExamPages().stream()
             .flatMap(p -> p.getExamItems().stream())
-            .map(examItem -> new Item(examItem.getItemKey()))
+            .map(examItem -> {
+                Item item = new Item(examItem.getItemKey());
+                item.setContentLevel("Strand|TL|D-R");
+                return item;
+            })
             .collect(Collectors.toList());
 
         assessment.getSegments().forEach(segment -> segment.setItems(assessmentItems));
@@ -169,7 +183,7 @@ public class OpportunityMapperTest {
             .collect(Collectors.toList())).isSubsetOf(
                 assessment.getSegments().stream()
                     .flatMap(segment -> segment.getItems().stream())
-                    .map(assessmentItem -> assessmentItem.getContentLevel())
+                    .map(assessmentItem -> "Strand")
                     .collect(Collectors.toList()));
     }
 


### PR DESCRIPTION
Example from TRT generated by StudentReportProcessor (legacy) [ignore extra quotes]
`<Item strand=""1"" contentLevel=""1|OA|C-3|m|3.OA.7""...>...`

https://jira.fairwaytech.com/browse/TDS-1036