### PR TITLE
Translating attribute name to match what is expected for TRT

### DIFF
--- a/src/main/java/tds/exam/results/mappers/ExamineeMapper.java
+++ b/src/main/java/tds/exam/results/mappers/ExamineeMapper.java
@@ -24,19 +24,16 @@ public class ExamineeMapper {
     private static final String DOB_ATTRIBUTE_ID = "DOB";
     private static final Logger log = LoggerFactory.getLogger(ExamineeMapper.class);
 
-    private static final Map<String, String> attributeNames = ImmutableMap.of(
-        DOB_ATTRIBUTE_ID, "Birthday",
-        "Gender", "Sex",
-        "LastName", "LastOrSurname",
-        "SSID", "StudentIdentifier"
-    );
-
-    private static final Map<String, String> relationshipNames = ImmutableMap.of(
-        "DistrictID", "ResponsibleDistrictIdentifier",
-        "DistrictName", "OrganizationName",
-        "SchoolID", "ResponsibleInstitutionIdentifier",
-        "SchoolName", "NameOfInstitution"
-    );
+    private static final Map<String, String> trtAttributeRelationshipTranslations = ImmutableMap.<String, String>builder()
+        .put(DOB_ATTRIBUTE_ID, "Birthday")
+        .put("Gender", "Sex")
+        .put("LastName", "LastOrSurname")
+        .put("SSID", "StudentIdentifier")
+        .put("DistrictID", "ResponsibleDistrictIdentifier")
+        .put("DistrictName", "OrganizationName")
+        .put("SchoolID", "ResponsibleInstitutionIdentifier")
+        .put("SchoolName", "NameOfInstitution")
+        .build();
 
     public static TDSReport.Examinee mapExaminee(final ExpandableExam expandableExam) {
         TDSReport.Examinee examinee = new TDSReport.Examinee();
@@ -47,8 +44,8 @@ public class ExamineeMapper {
             TDSReport.Examinee.ExamineeRelationship reportRelationship = new TDSReport.Examinee.ExamineeRelationship();
             // If there is a translated relationship name, use the translated name - See ReportingDLL - 1967-1972
             reportRelationship.setName(
-                relationshipNames.containsKey(relationship.getName())
-                    ? relationshipNames.get(relationship.getName())
+                trtAttributeRelationshipTranslations.containsKey(relationship.getName())
+                    ? trtAttributeRelationshipTranslations.get(relationship.getName())
                     : relationship.getName()
             );
             reportRelationship.setValue(relationship.getValue());
@@ -61,8 +58,8 @@ public class ExamineeMapper {
             TDSReport.Examinee.ExamineeAttribute reportAttribute = new TDSReport.Examinee.ExamineeAttribute();
             // If there is a translated attribute name, use the translated name - See ReportingDLL - 1920-1927
             reportAttribute.setName(
-                attributeNames.containsKey(attribute.getName())
-                    ? attributeNames.get(attribute.getName())
+                trtAttributeRelationshipTranslations.containsKey(attribute.getName())
+                    ? trtAttributeRelationshipTranslations.get(attribute.getName())
                     : attribute.getName()
             );
             reportAttribute.setValue(

--- a/src/main/java/tds/exam/results/mappers/ExamineeMapper.java
+++ b/src/main/java/tds/exam/results/mappers/ExamineeMapper.java
@@ -31,6 +31,13 @@ public class ExamineeMapper {
         "SSID", "StudentIdentifier"
     );
 
+    private static final Map<String, String> relationshipNames = ImmutableMap.of(
+        "DistrictID", "ResponsibleDistrictIdentifier",
+        "DistrictName", "OrganizationName",
+        "SchoolID", "ResponsibleInstitutionIdentifier",
+        "SchoolName", "NameOfInstitution"
+    );
+
     public static TDSReport.Examinee mapExaminee(final ExpandableExam expandableExam) {
         TDSReport.Examinee examinee = new TDSReport.Examinee();
         examinee.setKey(expandableExam.getExam().getStudentId());
@@ -38,7 +45,12 @@ public class ExamineeMapper {
 
         expandableExam.getExamineeRelationships().forEach(relationship -> {
             TDSReport.Examinee.ExamineeRelationship reportRelationship = new TDSReport.Examinee.ExamineeRelationship();
-            reportRelationship.setName(relationship.getName());
+            // If there is a translated relationship name, use the translated name - See ReportingDLL - 1967-1972
+            reportRelationship.setName(
+                relationshipNames.containsKey(relationship.getName())
+                    ? relationshipNames.get(relationship.getName())
+                    : relationship.getName()
+            );
             reportRelationship.setValue(relationship.getValue());
             reportRelationship.setContext(Context.fromValue(relationship.getContext().name()));
             reportRelationship.setContextDate(JaxbMapperUtils.convertInstantToGregorianCalendar(relationship.getCreatedAt()));

--- a/src/test/java/tds/exam/results/mappers/ExamineeMapperTest.java
+++ b/src/test/java/tds/exam/results/mappers/ExamineeMapperTest.java
@@ -22,49 +22,13 @@ public class ExamineeMapperTest {
 
     @Test
     public void shouldMapExamineeData() {
-        List<ExamineeAttribute> mockExamineeAttributes = randomListOf(2, ExamineeAttribute.class);
-        mockExamineeAttributes.add(
-            new ExamineeAttribute.Builder()
-                .withExamId(UUID.randomUUID())
-                .withName("DOB")
-                .withValue("10081990")
-                .withContext(ExamineeContext.INITIAL)
-                .withCreatedAt(Instant.now())
-                .build()
-        );
-        mockExamineeAttributes.add(
-            new ExamineeAttribute.Builder()
-                .withExamId(UUID.randomUUID())
-                .withName("Gender")
-                .withValue("M")
-                .withContext(ExamineeContext.INITIAL)
-                .withCreatedAt(Instant.now())
-                .build()
-        );
-        mockExamineeAttributes.add(
-            new ExamineeAttribute.Builder()
-                .withExamId(UUID.randomUUID())
-                .withName("SSID")
-                .withValue("1234567")
-                .withContext(ExamineeContext.INITIAL)
-                .withCreatedAt(Instant.now())
-                .build()
-        );
-        mockExamineeAttributes.add(
-            new ExamineeAttribute.Builder()
-                .withExamId(UUID.randomUUID())
-                .withName("LastName")
-                .withValue("Danzig")
-                .withContext(ExamineeContext.INITIAL)
-                .withCreatedAt(Instant.now())
-                .build()
-        );
-
+        List<ExamineeRelationship> mockExamineeRelationships = getExamineeRelationships();
+        List<ExamineeAttribute> mockExamineeAttributes = getExamineeAttributes();
         ExpandableExam expandableExam = new ExpandableExam.Builder(random(Exam.class))
             .withExamineeAttributes(mockExamineeAttributes)
-            .withExamineeRelationship(randomListOf(2, ExamineeRelationship.class))
+            .withExamineeRelationship(mockExamineeRelationships)
             .build();
-
+        
         TDSReport.Examinee examinee = ExamineeMapper.mapExaminee(expandableExam);
 
         assertThat(examinee.getExamineeAttributeOrExamineeRelationship().size())
@@ -124,5 +88,117 @@ public class ExamineeMapperTest {
                     && ((TDSReport.Examinee.ExamineeAttribute)attrOrRel).getName().equalsIgnoreCase("LastOrSurname"))
                 .findFirst().get();
         assertThat(lastNameAttribute.getValue()).isEqualTo("Danzig");
+
+        TDSReport.Examinee.ExamineeRelationship districtIdAttribute =
+            (TDSReport.Examinee.ExamineeRelationship)examinee.getExamineeAttributeOrExamineeRelationship().stream()
+                .filter(attrOrRel -> attrOrRel instanceof TDSReport.Examinee.ExamineeRelationship
+                    && ((TDSReport.Examinee.ExamineeRelationship)attrOrRel).getName().equalsIgnoreCase("ResponsibleDistrictIdentifier"))
+                .findFirst().get();
+        assertThat(districtIdAttribute.getValue()).isEqualTo("Sweetwater");
+
+        TDSReport.Examinee.ExamineeRelationship districtNameAttribute =
+            (TDSReport.Examinee.ExamineeRelationship)examinee.getExamineeAttributeOrExamineeRelationship().stream()
+                .filter(attrOrRel -> attrOrRel instanceof TDSReport.Examinee.ExamineeRelationship
+                    && ((TDSReport.Examinee.ExamineeRelationship)attrOrRel).getName().equalsIgnoreCase("OrganizationName"))
+                .findFirst().get();
+        assertThat(districtNameAttribute.getValue()).isEqualTo("District 9");
+
+        TDSReport.Examinee.ExamineeRelationship schoolIdRelationship =
+            (TDSReport.Examinee.ExamineeRelationship)examinee.getExamineeAttributeOrExamineeRelationship().stream()
+                .filter(attrOrRel -> attrOrRel instanceof TDSReport.Examinee.ExamineeRelationship
+                    && ((TDSReport.Examinee.ExamineeRelationship)attrOrRel).getName().equalsIgnoreCase("ResponsibleInstitutionIdentifier"))
+                .findFirst().get();
+        assertThat(schoolIdRelationship.getValue()).isEqualTo("Hilltop");
+
+        TDSReport.Examinee.ExamineeRelationship schoolNameRelationship =
+            (TDSReport.Examinee.ExamineeRelationship)examinee.getExamineeAttributeOrExamineeRelationship().stream()
+                .filter(attrOrRel -> attrOrRel instanceof TDSReport.Examinee.ExamineeRelationship
+                    && ((TDSReport.Examinee.ExamineeRelationship)attrOrRel).getName().equalsIgnoreCase("NameOfInstitution"))
+                .findFirst().get();
+        assertThat(schoolNameRelationship.getValue()).isEqualTo("School of Rock");
+
+
+    }
+
+    private List<ExamineeAttribute> getExamineeAttributes() {
+        List<ExamineeAttribute> mockExamineeAttributes = randomListOf(2, ExamineeAttribute.class);
+        mockExamineeAttributes.add(
+            new ExamineeAttribute.Builder()
+                .withExamId(UUID.randomUUID())
+                .withName("DOB")
+                .withValue("10081990")
+                .withContext(ExamineeContext.INITIAL)
+                .withCreatedAt(Instant.now())
+                .build()
+        );
+        mockExamineeAttributes.add(
+            new ExamineeAttribute.Builder()
+                .withExamId(UUID.randomUUID())
+                .withName("Gender")
+                .withValue("M")
+                .withContext(ExamineeContext.INITIAL)
+                .withCreatedAt(Instant.now())
+                .build()
+        );
+        mockExamineeAttributes.add(
+            new ExamineeAttribute.Builder()
+                .withExamId(UUID.randomUUID())
+                .withName("SSID")
+                .withValue("1234567")
+                .withContext(ExamineeContext.INITIAL)
+                .withCreatedAt(Instant.now())
+                .build()
+        );
+        mockExamineeAttributes.add(
+            new ExamineeAttribute.Builder()
+                .withExamId(UUID.randomUUID())
+                .withName("LastName")
+                .withValue("Danzig")
+                .withContext(ExamineeContext.INITIAL)
+                .withCreatedAt(Instant.now())
+                .build()
+        );
+        return mockExamineeAttributes;
+    }
+
+    private List<ExamineeRelationship> getExamineeRelationships() {
+        List<ExamineeRelationship> mockExamineeRelationships = randomListOf(2, ExamineeRelationship.class);
+        mockExamineeRelationships.add(
+            new ExamineeRelationship.Builder()
+                .withExamId(UUID.randomUUID())
+                .withName("DistrictID")
+                .withValue("Sweetwater")
+                .withContext(ExamineeContext.INITIAL)
+                .withCreatedAt(Instant.now())
+                .build()
+        );
+        mockExamineeRelationships.add(
+            new ExamineeRelationship.Builder()
+                .withExamId(UUID.randomUUID())
+                .withName("SchoolName")
+                .withValue("School of Rock")
+                .withContext(ExamineeContext.INITIAL)
+                .withCreatedAt(Instant.now())
+                .build()
+        );
+        mockExamineeRelationships.add(
+            new ExamineeRelationship.Builder()
+                .withExamId(UUID.randomUUID())
+                .withName("SchoolID")
+                .withValue("Hilltop")
+                .withContext(ExamineeContext.INITIAL)
+                .withCreatedAt(Instant.now())
+                .build()
+        );
+        mockExamineeRelationships.add(
+            new ExamineeRelationship.Builder()
+                .withExamId(UUID.randomUUID())
+                .withName("DistrictName")
+                .withValue("District 9")
+                .withContext(ExamineeContext.INITIAL)
+                .withCreatedAt(Instant.now())
+                .build()
+        );
+        return mockExamineeRelationships;
     }
 }


### PR DESCRIPTION
Fixing issue where some ExamineeRelationship attribute IDs did not match legacy