### PR TITLE
Checking for NULL DOB and returning a default date

### DIFF
--- a/src/main/java/tds/exam/results/mappers/ExamineeMapper.java
+++ b/src/main/java/tds/exam/results/mappers/ExamineeMapper.java
@@ -95,6 +95,11 @@ public class ExamineeMapper {
     private static String formatBirthDate(final String dob) {
         DateFormat tdsFormat = new SimpleDateFormat("MMddyyyy");
         DateFormat trtFormat = new SimpleDateFormat("yyyy-MM-dd");
+
+        if (dob == null) {
+            return DEFAULT_BIRTH_DATE;
+        }
+
         try {
             return trtFormat.format(tdsFormat.parse(dob));
         } catch (ParseException e) {

--- a/src/main/java/tds/exam/results/mappers/ExamineeMapper.java
+++ b/src/main/java/tds/exam/results/mappers/ExamineeMapper.java
@@ -15,6 +15,7 @@
 package tds.exam.results.mappers;
 
 import com.google.common.collect.ImmutableMap;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.access.method.P;
@@ -93,12 +94,12 @@ public class ExamineeMapper {
         The birthdate is typically formatted "MMDDYYYY" and is expected to be in "YYYY-MM-DD" - ReportingDLL.readTesteeAttributes()
      */
     private static String formatBirthDate(final String dob) {
-        DateFormat tdsFormat = new SimpleDateFormat("MMddyyyy");
-        DateFormat trtFormat = new SimpleDateFormat("yyyy-MM-dd");
-
-        if (dob == null) {
+        if (StringUtils.isBlank(dob)) {
             return DEFAULT_BIRTH_DATE;
         }
+
+        DateFormat tdsFormat = new SimpleDateFormat("MMddyyyy");
+        DateFormat trtFormat = new SimpleDateFormat("yyyy-MM-dd");
 
         try {
             return trtFormat.format(tdsFormat.parse(dob));


### PR DESCRIPTION
https://jira.fairwaytech.com/browse/TDS-1117

Under the false impression that DOB could never be null, we weren't checking for null. I am now checking for null and returning a default date of 1990-01-01, which is the same behavior as the legacy app.