### PR TITLE
Release 4.0.1.RELEASE to master

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <jaxb-maven.version>2.3.1</jaxb-maven.version>
 
         <!-- TDS Version Props -->
-        <tds-exam-client.version>4.0.1.RELEASE</tds-exam-client.version>
+        <tds-exam-client.version>4.0.5</tds-exam-client.version>
         <tds-common.version>4.0.1.RELEASE</tds-common.version>
         <tds-session-client.version>3.1.3.RELEASE</tds-session-client.version>
         <tds-assessment-client.version>4.0.0.RELEASE</tds-assessment-client.version>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opentestsystem.delivery</groupId>
     <artifactId>tds-exam-results-transmitter</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.0</version>
     <packaging>jar</packaging>
     <name>tds-exam-results-transmitter</name>
     <description>Report processor for TDS Exams</description>
@@ -300,7 +300,7 @@
         <connection>scm:git:https://github.com/SmarterApp/TDS_ExamResultsTransmitter.git</connection>
         <developerConnection>scm:git:git://github.com/SmarterApp/TDS_ExamResultsTransmitter.git</developerConnection>
         <url>https://github.com/SmarterApp/TDS_ExamResultsTransmitter</url>
-        <tag>HEAD</tag>
+        <tag>4.0.0</tag>
     </scm>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opentestsystem.delivery</groupId>
     <artifactId>tds-exam-results-transmitter</artifactId>
-    <version>4.0.0.RELEASE</version>
+    <version>4.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>tds-exam-results-transmitter</name>
     <description>Report processor for TDS Exams</description>
@@ -300,7 +300,7 @@
         <connection>scm:git:https://github.com/SmarterApp/TDS_ExamResultsTransmitter.git</connection>
         <developerConnection>scm:git:git://github.com/SmarterApp/TDS_ExamResultsTransmitter.git</developerConnection>
         <url>https://github.com/SmarterApp/TDS_ExamResultsTransmitter</url>
-        <tag>4.0.0.RELEASE</tag>
+        <tag>HEAD</tag>
     </scm>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opentestsystem.delivery</groupId>
     <artifactId>tds-exam-results-transmitter</artifactId>
-    <version>4.0.1-SNAPSHOT</version>
+    <version>4.0.1.RELEASE</version>
     <packaging>jar</packaging>
     <name>tds-exam-results-transmitter</name>
     <description>Report processor for TDS Exams</description>
@@ -300,7 +300,7 @@
         <connection>scm:git:https://github.com/SmarterApp/TDS_ExamResultsTransmitter.git</connection>
         <developerConnection>scm:git:git://github.com/SmarterApp/TDS_ExamResultsTransmitter.git</developerConnection>
         <url>https://github.com/SmarterApp/TDS_ExamResultsTransmitter</url>
-        <tag>HEAD</tag>
+        <tag>4.0.1.RELEASE</tag>
     </scm>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opentestsystem.delivery</groupId>
     <artifactId>tds-exam-results-transmitter</artifactId>
-    <version>4.0.0</version>
+    <version>4.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>tds-exam-results-transmitter</name>
     <description>Report processor for TDS Exams</description>
@@ -300,7 +300,7 @@
         <connection>scm:git:https://github.com/SmarterApp/TDS_ExamResultsTransmitter.git</connection>
         <developerConnection>scm:git:git://github.com/SmarterApp/TDS_ExamResultsTransmitter.git</developerConnection>
         <url>https://github.com/SmarterApp/TDS_ExamResultsTransmitter</url>
-        <tag>4.0.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <jaxb-maven.version>2.3.1</jaxb-maven.version>
 
         <!-- TDS Version Props -->
-        <tds-exam-client.version>4.0.5</tds-exam-client.version>
+        <tds-exam-client.version>4.0.6.RELEASE</tds-exam-client.version>
         <tds-common.version>4.0.1.RELEASE</tds-common.version>
         <tds-session-client.version>3.1.3.RELEASE</tds-session-client.version>
         <tds-assessment-client.version>4.0.0.RELEASE</tds-assessment-client.version>


### PR DESCRIPTION
Merge the 4.0.1.RELEASE tag into `master`.  This PR updates the `tds-exam` dependency to 4.0.6.RELEASE (the latest version)