### PR TITLE
Do not update status for expired exams

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <jaxb-maven.version>2.3.1</jaxb-maven.version>
 
         <!-- TDS Version Props -->
-        <tds-exam-client.version>4.0.6.RELEASE</tds-exam-client.version>
+        <tds-exam-client.version>4.1.2</tds-exam-client.version>
         <tds-common.version>4.0.1.RELEASE</tds-common.version>
         <tds-session-client.version>3.1.3.RELEASE</tds-session-client.version>
         <tds-assessment-client.version>4.0.0.RELEASE</tds-assessment-client.version>

--- a/src/main/java/tds/exam/results/messaging/ExamCompletedMessageListener.java
+++ b/src/main/java/tds/exam/results/messaging/ExamCompletedMessageListener.java
@@ -25,6 +25,7 @@ import java.util.UUID;
 import tds.exam.ExamStatusCode;
 import tds.exam.results.services.ExamResultsService;
 import tds.exam.results.services.ExamService;
+import tds.exam.results.trt.TDSReport;
 
 /**
  * This Messaging listener is responsible for handling Exam completion messages.
@@ -70,7 +71,11 @@ public class ExamCompletedMessageListener {
     private void processMessage(final String examId) {
         // Once this ERT message has been received, the exam status is "submitted"
         final UUID id = UUID.fromString(examId);
-        examResultsService.findAndSendExamResults(id);
-        examService.updateStatus(id, ExamStatusCode.STATUS_SUBMITTED);
+        TDSReport report = examResultsService.findAndSendExamResults(id);
+
+        //Expired Exams can have TRT's created.  However, those statuses do not get updated.
+        if(!report.getOpportunity().getStatus().equals(ExamStatusCode.STATUS_EXPIRED)) {
+            examService.updateStatus(id, ExamStatusCode.STATUS_SUBMITTED);
+        }
     }
 }


### PR DESCRIPTION
Since exams can be expired and TRT's created we need to not mark them as submitted as that isn't a valid status state transition.